### PR TITLE
feat(m1): token pipeline + EpConfigProvider

### DIFF
--- a/.changeset/m1-tokens.md
+++ b/.changeset/m1-tokens.md
@@ -1,0 +1,30 @@
+---
+"vue-ecosphere": minor
+"@ecosphere/tokens": minor
+---
+
+M1 — Token Pipeline
+
+- **New package `@ecosphere/tokens`** built via Style Dictionary v4: ships
+  `tokens.css`, `tokens.dark.css`, `tokens.scss`, `tokens.d.ts`, `tokens.js`,
+  `tokens.cjs`, and `tailwind.preset.cjs`. Three-tier hierarchy
+  (primitive → semantic → component) with the `--ep-*` prefix convention.
+- **`vue-ecosphere`** now consumes the token pipeline. The lib's bundled CSS
+  inlines `--ep-*` custom properties and re-aliases legacy `--color-*` and
+  `--font-*` vars to the new tokens for full backwards compatibility — no
+  existing component SCSS changes were required.
+- **New `<EpConfigProvider>` component** establishes a runtime config contract
+  for `theme` (`light` | `dark` | `auto` | `invert`), `size`, and `locale` via
+  `provide`/`inject` (`EpConfigKey`). When `theme="auto"` it sets
+  `data-theme="auto"` on `<html>` and live-reacts to
+  `prefers-color-scheme: dark` via a `matchMedia` listener that is torn down on
+  unmount.
+- **Theme helpers refactored**: `setTheme()` now sets `data-theme` on `<html>`
+  (while still toggling the legacy `body.ecosphere-dark` class), and
+  `setColors()` / `setFonts()` are deprecated with a `console.warn` — consumers
+  should override `--ep-color-*` / `--ep-font-family-*` CSS variables on
+  `:root` (or per-subtree via `<EpConfigProvider>`) instead.
+- Inter (default `--ep-font-family-base`) is an **opt-in font load**: consumers
+  install `@fontsource-variable/inter` and call
+  `import "@fontsource-variable/inter"` once at app entry. Opt-out by
+  overriding `--ep-font-family-base`.

--- a/packages/ecosphere/package.json
+++ b/packages/ecosphere/package.json
@@ -41,6 +41,7 @@
 		"node": ">=20"
 	},
 	"scripts": {
+		"prebuild": "pnpm --filter @ecosphere/tokens build",
 		"build": "vite build && vue-tsc -p tsconfig.build.json",
 		"dev": "vite build --watch",
 		"type-check": "vue-tsc --noEmit -p tsconfig.json",
@@ -50,6 +51,10 @@
 	},
 	"peerDependencies": {
 		"vue": "^3.4"
+	},
+	"dependencies": {
+		"@ecosphere/tokens": "workspace:*",
+		"@fontsource-variable/inter": "^5.1.0"
 	},
 	"devDependencies": {
 		"@size-limit/preset-small-lib": "^11.1.6",

--- a/packages/ecosphere/src/general/EpConfigProvider.vue
+++ b/packages/ecosphere/src/general/EpConfigProvider.vue
@@ -1,0 +1,86 @@
+<template>
+	<component :is="tag">
+		<slot />
+	</component>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, provide, ref, toRef, watch } from "vue";
+import type { theme as Theme } from "../utilities/types.interface";
+import { EpConfigKey, type EpLocale, type EpSize } from "./config";
+
+export interface EpConfigProviderProps {
+	/**
+	 * Active color theme. `"auto"` follows `prefers-color-scheme` and reacts
+	 * to OS-level changes at runtime.
+	 */
+	theme?: Theme;
+	/** Default component size for descendants that support sizing. */
+	size?: EpSize;
+	/** BCP-47 locale tag. Defaults to `navigator.language` or `"en"`. */
+	locale?: EpLocale;
+	/** Root element tag. Defaults to a fragment-like `<div>`. */
+	tag?: string;
+}
+
+const props = withDefaults(defineProps<EpConfigProviderProps>(), {
+	theme: "auto",
+	size: "md",
+	locale: undefined,
+	tag: "div",
+});
+
+const themeRef = toRef(props, "theme");
+const sizeRef = toRef(props, "size");
+const localeRef = ref<EpLocale>(
+	props.locale ??
+		(typeof navigator !== "undefined" ? navigator.language : "en")
+);
+
+watch(
+	() => props.locale,
+	(next) => {
+		if (next) localeRef.value = next;
+	}
+);
+
+provide(EpConfigKey, {
+	theme: themeRef,
+	size: sizeRef,
+	locale: localeRef,
+});
+
+const tag = computed(() => props.tag);
+
+// ---- Theme application + prefers-color-scheme listener ----
+let mediaQuery: MediaQueryList | null = null;
+let mediaListener: ((event: MediaQueryListEvent) => void) | null = null;
+
+function teardown(): void {
+	if (mediaQuery && mediaListener) {
+		mediaQuery.removeEventListener("change", mediaListener);
+	}
+	mediaQuery = null;
+	mediaListener = null;
+}
+
+function apply(next: Theme): void {
+	if (typeof document === "undefined") return;
+	teardown();
+	const root = document.documentElement;
+	root.setAttribute("data-theme", next);
+
+	if (next === "auto" && typeof window !== "undefined" && window.matchMedia) {
+		mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+		document.body.classList.toggle("ecosphere-dark", mediaQuery.matches);
+		mediaListener = (event) =>
+			document.body.classList.toggle("ecosphere-dark", event.matches);
+		mediaQuery.addEventListener("change", mediaListener);
+	} else {
+		document.body.classList.toggle("ecosphere-dark", next === "dark");
+	}
+}
+
+watch(themeRef, (next) => apply(next), { immediate: true });
+onBeforeUnmount(teardown);
+</script>

--- a/packages/ecosphere/src/general/config.ts
+++ b/packages/ecosphere/src/general/config.ts
@@ -1,0 +1,13 @@
+import type { InjectionKey, Ref } from "vue";
+import type { theme } from "../utilities/types.interface";
+
+export type EpSize = "xs" | "sm" | "md" | "lg" | "xl";
+export type EpLocale = string;
+
+export interface EpConfig {
+	theme: Ref<theme>;
+	size: Ref<EpSize>;
+	locale: Ref<EpLocale>;
+}
+
+export const EpConfigKey: InjectionKey<EpConfig> = Symbol("EpConfig");

--- a/packages/ecosphere/src/index.ts
+++ b/packages/ecosphere/src/index.ts
@@ -1,3 +1,8 @@
+// Token pipeline — design tokens as CSS custom properties (--ep-*).
+// These two CSS imports are inlined into the lib's bundled stylesheet by Vite.
+import "@ecosphere/tokens/css";
+import "@ecosphere/tokens/css/dark";
+
 // Components
 import ButtonComponent from "./call-to-action/ButtonComponent.vue";
 import LinkComponent from "./call-to-action/LinkComponent.vue";
@@ -15,6 +20,7 @@ import SwitchComponent from "./data-entry/SwitchComponent.vue";
 import TextareaField from "./data-entry/TextareaField.vue";
 
 import SVGIcon from "./general/SVGIcon.vue";
+import EpConfigProviderComponent from "./general/EpConfigProvider.vue";
 
 import AvatarComponent from "./miscellaneous/AvatarComponent.vue";
 import StepperComponent from "./miscellaneous/StepperComponent.vue";
@@ -47,6 +53,7 @@ export const EpSearchDropdown = SearchDropdown;
 export const EpSwitch = SwitchComponent;
 export const EpTextarea = TextareaField;
 export const EpIcon = SVGIcon;
+export const EpConfigProvider = EpConfigProviderComponent;
 export const EpAvatar = AvatarComponent;
 export const EpStepper = StepperComponent;
 export const EpTag = TagComponent;
@@ -84,6 +91,12 @@ export {
 
 // Public types
 export * from "./utilities/types.interface";
+export {
+	EpConfigKey,
+	type EpConfig,
+	type EpSize,
+	type EpLocale,
+} from "./general/config";
 
 // GlobalComponents type augmentation for template auto-completion
 declare module "vue" {
@@ -102,6 +115,7 @@ declare module "vue" {
 		EpSwitch: typeof SwitchComponent;
 		EpTextarea: typeof TextareaField;
 		EpIcon: typeof SVGIcon;
+		EpConfigProvider: typeof EpConfigProviderComponent;
 		EpAvatar: typeof AvatarComponent;
 		EpStepper: typeof StepperComponent;
 		EpTag: typeof TagComponent;

--- a/packages/ecosphere/src/plugin_components.ts
+++ b/packages/ecosphere/src/plugin_components.ts
@@ -19,6 +19,7 @@ import TextareaField from "./data-entry/TextareaField.vue";
 
 // General
 import SVGIcon from "./general/SVGIcon.vue";
+import EpConfigProvider from "./general/EpConfigProvider.vue";
 
 // Miscellaneous
 import AvatarComponent from "./miscellaneous/AvatarComponent.vue";
@@ -57,6 +58,7 @@ export default function registerPluginComponents(app: App) {
 
 	// General
 	app.component("EpIcon", SVGIcon);
+	app.component("EpConfigProvider", EpConfigProvider);
 
 	// Miscellaneous
 	app.component("EpAvatar", AvatarComponent);

--- a/packages/ecosphere/src/styles/_colors.scss
+++ b/packages/ecosphere/src/styles/_colors.scss
@@ -1,99 +1,91 @@
-// ---------- Base ----------
+// ---------- Compatibility aliases for legacy --color-* names ----------
+// All values are sourced from the @ecosphere/tokens pipeline (--ep-color-*).
+// Consumers can override behavior by setting --ep-color-* on :root.
 :root {
 	// Elementary
-	--color-light: #ffffff;
-	--color-light-faded: #edf2f7;
-	--color-dark: #0d0f11;
-	--color-dark-faded: #202b35;
+	--color-light: var(--ep-primitive-color-light);
+	--color-light-faded: var(--ep-primitive-color-light-faded);
+	--color-dark: var(--ep-primitive-color-dark);
+	--color-dark-faded: var(--ep-primitive-color-dark-faded);
+
+	// Semantic surfaces
+	--color-background: var(--ep-color-background);
+	--color-background-faded: var(--ep-color-background-faded);
+	--color-contrast: var(--ep-color-contrast);
+	--color-contrast-faded: var(--ep-color-contrast-faded);
 
 	// Brand
-	--color-primary: #0b3567;
-	--color-primary-contrast: #fefefe;
-	--color-primary-variant: #ade8f4;
-	--color-primary-variant-contrast: #1a2129;
-	--color-secondary: #bbadff;
-	--color-secondary-contrast: #160a22;
-	--color-secondary-variant: #c4c7ff;
-	--color-secondary-variant-contrast: #18192e;
+	--color-primary: var(--ep-color-primary);
+	--color-primary-contrast: var(--ep-color-primary-contrast);
+	--color-primary-variant: var(--ep-color-primary-variant);
+	--color-primary-variant-contrast: var(--ep-color-primary-variant-contrast);
+	--color-secondary: var(--ep-color-secondary);
+	--color-secondary-contrast: var(--ep-color-secondary-contrast);
+	--color-secondary-variant: var(--ep-color-secondary-variant);
+	--color-secondary-variant-contrast: var(--ep-color-secondary-variant-contrast);
 
 	// Helpers
-	--color-transparent: transparent;
-	--color-hyperlink: #56abff;
-	--color-divider: #d2d0d0;
-	--color-disabled: #a1a1a1;
-	--color-offline: #e8eae6;
+	--color-transparent: var(--ep-color-transparent);
+	--color-hyperlink: var(--ep-color-hyperlink);
+	--color-divider: var(--ep-color-divider);
+	--color-disabled: var(--ep-color-disabled);
+	--color-offline: var(--ep-color-offline);
 
 	// Indicators
-	--color-error: #ff7878;
-	--color-error-variant: #fc9a9a;
-	--color-success: #71e2b2;
-	--color-success-variant: #96f8cf;
-	--color-warning: #ffcc1d;
-	--color-warning-variant: #fad459;
-	--color-information: #8dc6ff;
-	--color-information-variant: #a6ccf1;
+	--color-error: var(--ep-color-error);
+	--color-error-variant: var(--ep-color-error-variant);
+	--color-success: var(--ep-color-success);
+	--color-success-variant: var(--ep-color-success-variant);
+	--color-warning: var(--ep-color-warning);
+	--color-warning-variant: var(--ep-color-warning-variant);
+	--color-information: var(--ep-color-information);
+	--color-information-variant: var(--ep-color-information-variant);
 }
 
-// ---------- Semantic Colors - CSS Variables ----------
-:root {
-	// Elementary
-	--color-background: var(--color-light);
-	--color-background-faded: var(--color-light-faded);
-	--color-contrast: var(--color-dark);
-	--color-contrast-faded: var(--color-dark-faded);
-}
-// @media (prefers-color-scheme: dark) {
-// 	:root {
-// 		// Elementary
-// 		--color-background: var(--color-dark);
-// 		--color-background-faded: var(--color-dark-faded);
-// 		--color-contrast: var(--color-light);
-// 		--color-contrast-faded: var(--color-light-faded);
-// 	}
-// }
-
+// Legacy body.ecosphere-dark hook — kept for back-compat with apps that toggle
+// the class directly. New code should set [data-theme="dark"] on <html> via
+// EpConfigProvider (preferred).
 body.ecosphere-dark {
-	// Elementary
-	--color-background: var(--color-dark);
-	--color-background-faded: var(--color-dark-faded);
-	--color-contrast: var(--color-light);
-	--color-contrast-faded: var(--color-light-faded);
+	--color-background: var(--ep-primitive-color-dark);
+	--color-background-faded: var(--ep-primitive-color-dark-faded);
+	--color-contrast: var(--ep-primitive-color-light);
+	--color-contrast-faded: var(--ep-primitive-color-light-faded);
 }
 
-// ---------- SCSS Variables ----------
+// ---------- SCSS variable aliases (consume CSS custom properties) ----------
 // Elementary
-$color-light: var(--color-light);
-$color-light-faded: var(--color-light-faded);
-$color-dark: var(--color-dark);
-$color-dark-faded: var(--color-dark-faded);
-$color-background: var(--color-background);
-$color-background-faded: var(--color-background-faded);
-$color-contrast: var(--color-contrast);
-$color-contrast-faded: var(--color-contrast-faded);
+$color-light: var(--ep-primitive-color-light);
+$color-light-faded: var(--ep-primitive-color-light-faded);
+$color-dark: var(--ep-primitive-color-dark);
+$color-dark-faded: var(--ep-primitive-color-dark-faded);
+$color-background: var(--ep-color-background);
+$color-background-faded: var(--ep-color-background-faded);
+$color-contrast: var(--ep-color-contrast);
+$color-contrast-faded: var(--ep-color-contrast-faded);
 
 // Brand
-$color-primary: var(--color-primary);
-$color-primary-contrast: var(--color-primary-contrast);
-$color-primary-variant: var(--color-primary-variant);
-$color-primary-variant-contrast: var(--color-primary-variant-contrast);
-$color-secondary: var(--color-secondary);
-$color-secondary-contrast: var(--color-secondary-contrast);
-$color-secondary-variant: var(--color-secondary-variant);
-$color-secondary-variant-contrast: var(--color-secondary-variant-contrast);
+$color-primary: var(--ep-color-primary);
+$color-primary-contrast: var(--ep-color-primary-contrast);
+$color-primary-variant: var(--ep-color-primary-variant);
+$color-primary-variant-contrast: var(--ep-color-primary-variant-contrast);
+$color-secondary: var(--ep-color-secondary);
+$color-secondary-contrast: var(--ep-color-secondary-contrast);
+$color-secondary-variant: var(--ep-color-secondary-variant);
+$color-secondary-variant-contrast: var(--ep-color-secondary-variant-contrast);
 
 // Helpers
-$color-transparent: var(--color-transparent);
-$color-hyperlink: var(--color-hyperlink);
-$color-divider: var(--color-divider);
-$color-disabled: var(--color-disabled);
-$color-offline: var(--color-offline);
+$color-transparent: var(--ep-color-transparent);
+$color-hyperlink: var(--ep-color-hyperlink);
+$color-divider: var(--ep-color-divider);
+$color-disabled: var(--ep-color-disabled);
+$color-offline: var(--ep-color-offline);
 
 // Indicators
-$color-error: var(--color-error);
-$color-error-variant: var(--color-error-variant);
-$color-success: var(--color-success);
-$color-success-variant: var(--color-success-variant);
-$color-warning: var(--color-warning);
-$color-warning-variant: var(--color-warning-variant);
-$color-information: var(--color-information);
-$color-information-variant: var(--color-information-variant);
+$color-error: var(--ep-color-error);
+$color-error-variant: var(--ep-color-error-variant);
+$color-success: var(--ep-color-success);
+$color-success-variant: var(--ep-color-success-variant);
+$color-warning: var(--ep-color-warning);
+$color-warning-variant: var(--ep-color-warning-variant);
+$color-information: var(--ep-color-information);
+$color-information-variant: var(--ep-color-information-variant);

--- a/packages/ecosphere/src/styles/_fonts.scss
+++ b/packages/ecosphere/src/styles/_fonts.scss
@@ -1,16 +1,17 @@
-@import url("https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap");
-
+// ---------- Font family aliases ----------
+// Sources: @ecosphere/tokens (--ep-font-family-*).
+// Inter is the default `--ep-font-family-base`. Consumers opt-out by setting
+// `--ep-font-family-base` on :root. Install `@fontsource-variable/inter` and
+// `import "@fontsource-variable/inter"` once at app entry to load the webfont.
 :root {
-	--font-general: "Work Sans", -apple-system, sans-serif;
-	--font-serif: "Libre Baskerville", serif;
-	--font-monospace: "Roboto Mono", monospace;
+	--font-general: var(--ep-font-family-base);
+	--font-serif: var(--ep-font-family-serif);
+	--font-monospace: var(--ep-font-family-mono);
 }
 
-$font-general: var(--font-general);
-$font-serif: var(--font-serif);
-$font-monospace: var(--font-monospace);
+$font-general: var(--ep-font-family-base);
+$font-serif: var(--ep-font-family-serif);
+$font-monospace: var(--ep-font-family-mono);
 
 @mixin font-light {
 	font-family: $font-general;

--- a/packages/ecosphere/src/styles/_variables.scss
+++ b/packages/ecosphere/src/styles/_variables.scss
@@ -1,6 +1,8 @@
-$border-radius-standard: 0.5rem;
-$transition-standard: all 0.3s ease-in-out;
+// ---------- Misc variable aliases ----------
+// Sources: @ecosphere/tokens. Override --ep-* on :root to customize.
+$border-radius-standard: var(--ep-radius-base);
+$transition-standard: var(--ep-transition-base);
 $reading-width-standard: 850px;
-$box-shadow-standard: $color-disabled 0px 2px 8px;
-$box-shadow-heavy: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-$outline-focus: 1px solid $color-hyperlink;
+$box-shadow-standard: var(--ep-shadow-md);
+$box-shadow-heavy: var(--ep-shadow-lg);
+$outline-focus: var(--ep-outline-focus);

--- a/packages/ecosphere/src/utilities/helpers/theme.ts
+++ b/packages/ecosphere/src/utilities/helpers/theme.ts
@@ -1,32 +1,95 @@
 import type { theme, unknown_object } from "../../utilities/types.interface";
 
-export function setTheme(theme: theme = "auto") {
-	document.body.classList.remove("ecosphere-dark");
-	if (
-		(theme === "auto" &&
-			window.matchMedia &&
-			window.matchMedia("(prefers-color-scheme:dark)").matches) ||
-		theme === "dark"
-	) {
-		document.body.classList.add("ecosphere-dark");
-	}
+let darkMediaQuery: MediaQueryList | null = null;
+let darkMediaListener: ((event: MediaQueryListEvent) => void) | null = null;
+
+function applyTheme(resolved: "light" | "dark"): void {
+	if (typeof document === "undefined") return;
+	const root = document.documentElement;
+	root.setAttribute("data-theme", resolved);
+
+	// Legacy hook — keep body class in sync for any consumer still styling
+	// against `body.ecosphere-dark`. Removed in a future major.
+	document.body.classList.toggle("ecosphere-dark", resolved === "dark");
 }
 
-export function setColors(colors: unknown_object) {
-	const root: any = document.querySelector(":root");
+function teardownAutoListener(): void {
+	if (darkMediaQuery && darkMediaListener) {
+		darkMediaQuery.removeEventListener("change", darkMediaListener);
+	}
+	darkMediaQuery = null;
+	darkMediaListener = null;
+}
+
+export function setTheme(theme: theme = "auto"): void {
+	if (typeof document === "undefined") return;
+	teardownAutoListener();
+
+	if (theme === "auto") {
+		document.documentElement.setAttribute("data-theme", "auto");
+		if (typeof window !== "undefined" && window.matchMedia) {
+			darkMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+			applyTheme(darkMediaQuery.matches ? "dark" : "light");
+			// Re-apply data-theme="auto" so the CSS @media block governs values;
+			// the body class above is the only DOM signal for legacy callers.
+			document.documentElement.setAttribute("data-theme", "auto");
+			darkMediaListener = (event: MediaQueryListEvent) => {
+				document.body.classList.toggle("ecosphere-dark", event.matches);
+			};
+			darkMediaQuery.addEventListener("change", darkMediaListener);
+		} else {
+			applyTheme("light");
+		}
+		return;
+	}
+
+	applyTheme(theme === "invert" ? "dark" : theme);
+}
+
+/**
+ * @deprecated Override `--ep-color-*` CSS custom properties on `:root` (or any
+ * scoped ancestor) instead. Will be removed in a future major release.
+ */
+export function setColors(colors: unknown_object): void {
+	if (typeof console !== "undefined") {
+		console.warn(
+			'[vue-ecosphere] setColors() is deprecated. Override --ep-color-* CSS variables on :root (or use <EpConfigProvider :colors="...">) instead.'
+		);
+	}
+	if (typeof document === "undefined") return;
+	const root = document.documentElement;
 	for (const color in colors) {
-		root.style.setProperty(`--color-${color}`, colors[color]);
+		root.style.setProperty(`--color-${color}`, String(colors[color]));
+		root.style.setProperty(`--ep-color-${color}`, String(colors[color]));
 	}
 }
 
-export function setFonts(fonts: unknown_object) {
-	const root: any = document.querySelector(":root");
+/**
+ * @deprecated Override `--ep-font-family-*` CSS custom properties on `:root`
+ * instead. Will be removed in a future major release.
+ */
+export function setFonts(fonts: unknown_object): void {
+	if (typeof console !== "undefined") {
+		console.warn(
+			"[vue-ecosphere] setFonts() is deprecated. Override --ep-font-family-* CSS variables on :root instead."
+		);
+	}
+	if (typeof document === "undefined") return;
+	const root = document.documentElement;
 	for (const font in fonts) {
-		root.style.setProperty(`--font-${font}`, fonts[font]);
+		root.style.setProperty(`--font-${font}`, String(fonts[font]));
+		const epKey = font === "general" ? "base" : font;
+		root.style.setProperty(
+			`--ep-font-family-${epKey}`,
+			String(fonts[font])
+		);
 	}
 }
 
 export function getTheme(): theme {
+	if (typeof document === "undefined") return "light";
+	const attr = document.documentElement.getAttribute("data-theme");
+	if (attr === "dark" || attr === "light" || attr === "auto") return attr;
 	return document.body.classList.contains("ecosphere-dark")
 		? "dark"
 		: "light";

--- a/packages/tokens/.gitignore
+++ b/packages/tokens/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "@ecosphere/tokens",
+	"version": "0.1.0",
+	"description": "Design tokens for vue-ecosphere (Style Dictionary v4 output)",
+	"license": "MIT",
+	"author": "bacon-delight",
+	"type": "module",
+	"sideEffects": [
+		"**/*.css",
+		"**/*.scss"
+	],
+	"files": [
+		"dist",
+		"src"
+	],
+	"main": "./dist/tokens.cjs",
+	"module": "./dist/tokens.js",
+	"types": "./dist/tokens.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/tokens.d.ts",
+			"import": "./dist/tokens.js",
+			"require": "./dist/tokens.cjs"
+		},
+		"./css": "./dist/tokens.css",
+		"./css/dark": "./dist/tokens.dark.css",
+		"./scss": "./dist/tokens.scss",
+		"./tailwind": "./dist/tailwind.preset.cjs",
+		"./package.json": "./package.json"
+	},
+	"engines": {
+		"node": ">=20"
+	},
+	"scripts": {
+		"build": "node scripts/build.mjs",
+		"clean": "rimraf dist"
+	},
+	"devDependencies": {
+		"rimraf": "^6.0.1",
+		"style-dictionary": "^4.3.0"
+	}
+}

--- a/packages/tokens/scripts/build.mjs
+++ b/packages/tokens/scripts/build.mjs
@@ -1,0 +1,198 @@
+import StyleDictionary from "style-dictionary";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+const distDir = resolve(root, "dist");
+mkdirSync(distDir, { recursive: true });
+
+const getValue = (t) => t.$value ?? t.value;
+
+StyleDictionary.registerFormat({
+	name: "css/ep-theme-light",
+	format: ({ dictionary, options }) => {
+		const prefix = options.prefix ?? "ep";
+		const lines = dictionary.allTokens.map(
+			(t) => `\t--${prefix}-${t.path.join("-")}: ${getValue(t)};`
+		);
+		return `/* vue-ecosphere tokens — light theme */\n:root,\n:root[data-theme="light"] {\n${lines.join("\n")}\n}\n`;
+	},
+});
+
+StyleDictionary.registerFormat({
+	name: "css/ep-theme-dark",
+	format: ({ dictionary, options }) => {
+		const prefix = options.prefix ?? "ep";
+		const lines = dictionary.allTokens.map(
+			(t) => `\t--${prefix}-${t.path.join("-")}: ${getValue(t)};`
+		);
+		const block = lines.join("\n");
+		const blockIndented = lines.map((l) => `\t${l}`).join("\n");
+		return `/* vue-ecosphere tokens — dark theme */\n:root[data-theme="dark"] {\n${block}\n}\n\n@media (prefers-color-scheme: dark) {\n\t:root[data-theme="auto"] {\n${blockIndented}\n\t}\n}\n`;
+	},
+});
+
+StyleDictionary.registerFormat({
+	name: "scss/ep-variables",
+	format: ({ dictionary, options }) => {
+		const prefix = options.prefix ?? "ep";
+		const lines = dictionary.allTokens.map(
+			(t) =>
+				`$${prefix}-${t.path.join("-")}: var(--${prefix}-${t.path.join("-")});`
+		);
+		return `/* vue-ecosphere tokens — SCSS variables */\n${lines.join("\n")}\n`;
+	},
+});
+
+StyleDictionary.registerFormat({
+	name: "ts/ep-tokens",
+	format: ({ dictionary, options }) => {
+		const prefix = options.prefix ?? "ep";
+		const cssVarMap = dictionary.allTokens
+			.map(
+				(t) =>
+					`\t"${t.path.join(".")}": "var(--${prefix}-${t.path.join("-")})",`
+			)
+			.join("\n");
+		const valueMap = dictionary.allTokens
+			.map(
+				(t) =>
+					`\t"${t.path.join(".")}": ${JSON.stringify(getValue(t))},`
+			)
+			.join("\n");
+		return `/* vue-ecosphere tokens — generated, do not edit */
+export declare const tokens: {
+${cssVarMap}
+};
+
+export declare const tokenValues: {
+${valueMap}
+};
+
+export type TokenName = keyof typeof tokens;
+`;
+	},
+});
+
+StyleDictionary.registerFormat({
+	name: "js/ep-tokens-esm",
+	format: ({ dictionary, options }) => {
+		const prefix = options.prefix ?? "ep";
+		const map = dictionary.allTokens
+			.map(
+				(t) =>
+					`\t"${t.path.join(".")}": "var(--${prefix}-${t.path.join("-")})",`
+			)
+			.join("\n");
+		const values = dictionary.allTokens
+			.map(
+				(t) =>
+					`\t"${t.path.join(".")}": ${JSON.stringify(getValue(t))},`
+			)
+			.join("\n");
+		return `/* vue-ecosphere tokens — generated */\nexport const tokens = {\n${map}\n};\nexport const tokenValues = {\n${values}\n};\n`;
+	},
+});
+
+StyleDictionary.registerFormat({
+	name: "cjs/ep-tokens",
+	format: ({ dictionary, options }) => {
+		const prefix = options.prefix ?? "ep";
+		const map = dictionary.allTokens
+			.map(
+				(t) =>
+					`\t"${t.path.join(".")}": "var(--${prefix}-${t.path.join("-")})",`
+			)
+			.join("\n");
+		const values = dictionary.allTokens
+			.map(
+				(t) =>
+					`\t"${t.path.join(".")}": ${JSON.stringify(getValue(t))},`
+			)
+			.join("\n");
+		return `/* vue-ecosphere tokens — generated */\nmodule.exports.tokens = {\n${map}\n};\nmodule.exports.tokenValues = {\n${values}\n};\n`;
+	},
+});
+
+const baseConfig = {
+	source: [
+		resolve(root, "src/primitive.tokens.json"),
+		resolve(root, "src/semantic.tokens.json"),
+		resolve(root, "src/component.tokens.json"),
+	],
+	platforms: {
+		main: {
+			buildPath: "dist/",
+			options: { prefix: "ep" },
+			files: [
+				{ destination: "tokens.css", format: "css/ep-theme-light" },
+				{ destination: "tokens.scss", format: "scss/ep-variables" },
+				{ destination: "tokens.d.ts", format: "ts/ep-tokens" },
+				{ destination: "tokens.js", format: "js/ep-tokens-esm" },
+				{ destination: "tokens.cjs", format: "cjs/ep-tokens" },
+			],
+		},
+	},
+};
+
+const darkConfig = {
+	source: [
+		resolve(root, "src/primitive.tokens.json"),
+		resolve(root, "src/semantic.dark.tokens.json"),
+	],
+	platforms: {
+		dark: {
+			buildPath: "dist/",
+			options: { prefix: "ep" },
+			files: [
+				{
+					destination: "tokens.dark.css",
+					format: "css/ep-theme-dark",
+					filter: (t) =>
+						t.filePath.includes("semantic.dark.tokens.json"),
+				},
+			],
+		},
+	},
+};
+
+const sd = new StyleDictionary(baseConfig);
+await sd.buildAllPlatforms();
+
+const sdDark = new StyleDictionary(darkConfig);
+await sdDark.buildAllPlatforms();
+
+const tailwindPreset = `/* vue-ecosphere tailwind preset — generated */
+module.exports = {
+	theme: {
+		extend: {
+			colors: {
+				"ep-background": "var(--ep-color-background)",
+				"ep-contrast": "var(--ep-color-contrast)",
+				"ep-primary": "var(--ep-color-primary)",
+				"ep-secondary": "var(--ep-color-secondary)",
+				"ep-error": "var(--ep-color-error)",
+				"ep-success": "var(--ep-color-success)",
+				"ep-warning": "var(--ep-color-warning)",
+				"ep-information": "var(--ep-color-information)",
+				"ep-divider": "var(--ep-color-divider)",
+				"ep-disabled": "var(--ep-color-disabled)",
+				"ep-hyperlink": "var(--ep-color-hyperlink)",
+			},
+			fontFamily: {
+				"ep-base": "var(--ep-font-family-base)",
+				"ep-serif": "var(--ep-font-family-serif)",
+				"ep-mono": "var(--ep-font-family-mono)",
+			},
+			borderRadius: {
+				"ep-base": "var(--ep-radius-base)",
+			},
+		},
+	},
+};
+`;
+writeFileSync(resolve(distDir, "tailwind.preset.cjs"), tailwindPreset);
+
+console.log("✓ @ecosphere/tokens built → dist/");

--- a/packages/tokens/src/component.tokens.json
+++ b/packages/tokens/src/component.tokens.json
@@ -1,0 +1,56 @@
+{
+	"button": {
+		"radius": { "value": "{radius.base}" },
+		"transition": { "value": "{transition.base}" },
+		"font-family": { "value": "{font.family.base}" },
+		"font-weight": { "value": "{primitive.font.weight.semibold}" },
+
+		"size": {
+			"xs": {
+				"height": { "value": "1.5rem" },
+				"padding-x": { "value": "{primitive.spacing.2}" },
+				"font-size": { "value": "{primitive.font.size.xs}" }
+			},
+			"sm": {
+				"height": { "value": "2rem" },
+				"padding-x": { "value": "{primitive.spacing.3}" },
+				"font-size": { "value": "{primitive.font.size.sm}" }
+			},
+			"md": {
+				"height": { "value": "2.5rem" },
+				"padding-x": { "value": "{primitive.spacing.4}" },
+				"font-size": { "value": "{primitive.font.size.md}" }
+			},
+			"lg": {
+				"height": { "value": "3rem" },
+				"padding-x": { "value": "{primitive.spacing.5}" },
+				"font-size": { "value": "{primitive.font.size.lg}" }
+			},
+			"xl": {
+				"height": { "value": "3.5rem" },
+				"padding-x": { "value": "{primitive.spacing.6}" },
+				"font-size": { "value": "{primitive.font.size.xl}" }
+			}
+		}
+	},
+
+	"input": {
+		"radius": { "value": "{radius.base}" },
+		"height": { "value": "2.5rem" },
+		"padding-x": { "value": "{primitive.spacing.3}" },
+		"font-family": { "value": "{font.family.base}" },
+		"font-size": { "value": "{primitive.font.size.md}" },
+		"border-color": { "value": "{color.divider}" }
+	},
+
+	"tag": {
+		"radius": { "value": "{primitive.radius.sm}" },
+		"padding-x": { "value": "{primitive.spacing.2}" },
+		"padding-y": { "value": "{primitive.spacing.1}" },
+		"font-size": { "value": "{primitive.font.size.xs}" }
+	},
+
+	"avatar": {
+		"radius": { "value": "{primitive.radius.full}" }
+	}
+}

--- a/packages/tokens/src/primitive.tokens.json
+++ b/packages/tokens/src/primitive.tokens.json
@@ -1,0 +1,111 @@
+{
+	"primitive": {
+		"color": {
+			"light": { "value": "#ffffff" },
+			"light-faded": { "value": "#edf2f7" },
+			"dark": { "value": "#0d0f11" },
+			"dark-faded": { "value": "#202b35" },
+
+			"blue": {
+				"100": { "value": "#e7f1fa" },
+				"300": { "value": "#8dc6ff" },
+				"500": { "value": "#56abff" },
+				"700": { "value": "#0b3567" },
+				"900": { "value": "#0a2546" }
+			},
+			"cyan": {
+				"300": { "value": "#ade8f4" },
+				"700": { "value": "#1a2129" }
+			},
+			"purple": {
+				"300": { "value": "#c4c7ff" },
+				"500": { "value": "#bbadff" },
+				"700": { "value": "#18192e" },
+				"900": { "value": "#160a22" }
+			},
+			"red": {
+				"300": { "value": "#fc9a9a" },
+				"500": { "value": "#ff7878" }
+			},
+			"green": {
+				"300": { "value": "#96f8cf" },
+				"500": { "value": "#71e2b2" }
+			},
+			"yellow": {
+				"300": { "value": "#fad459" },
+				"500": { "value": "#ffcc1d" }
+			},
+			"grey": {
+				"100": { "value": "#e8eae6" },
+				"300": { "value": "#d2d0d0" },
+				"500": { "value": "#a1a1a1" }
+			}
+		},
+
+		"spacing": {
+			"0": { "value": "0" },
+			"1": { "value": "0.25rem" },
+			"2": { "value": "0.5rem" },
+			"3": { "value": "0.75rem" },
+			"4": { "value": "1rem" },
+			"5": { "value": "1.25rem" },
+			"6": { "value": "1.5rem" },
+			"8": { "value": "2rem" },
+			"10": { "value": "2.5rem" },
+			"12": { "value": "3rem" },
+			"16": { "value": "4rem"}
+		},
+
+		"radius": {
+			"none": { "value": "0" },
+			"sm": { "value": "0.25rem" },
+			"md": { "value": "0.5rem" },
+			"lg": { "value": "1rem" },
+			"full": { "value": "9999px" }
+		},
+
+		"font": {
+			"family": {
+				"inter": { "value": "\"Inter Variable\", \"Inter\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif" },
+				"work-sans": { "value": "\"Work Sans\", -apple-system, sans-serif" },
+				"serif": { "value": "\"Libre Baskerville\", Georgia, serif" },
+				"mono": { "value": "\"Roboto Mono\", \"SF Mono\", Menlo, monospace" }
+			},
+			"size": {
+				"xs": { "value": "0.75rem" },
+				"sm": { "value": "0.875rem" },
+				"md": { "value": "1rem" },
+				"lg": { "value": "1.125rem" },
+				"xl": { "value": "1.25rem" },
+				"2xl": { "value": "1.5rem" },
+				"3xl": { "value": "1.75rem" },
+				"4xl": { "value": "2rem" },
+				"5xl": { "value": "2.25rem" }
+			},
+			"weight": {
+				"light": { "value": "300" },
+				"regular": { "value": "400" },
+				"medium": { "value": "500" },
+				"semibold": { "value": "600" },
+				"bold": { "value": "700" }
+			},
+			"line-height": {
+				"tight": { "value": "1.25" },
+				"normal": { "value": "1.5" },
+				"loose": { "value": "1.75" }
+			}
+		},
+
+		"duration": {
+			"fast": { "value": "150ms" },
+			"normal": { "value": "300ms" },
+			"slow": { "value": "500ms" }
+		},
+
+		"easing": {
+			"standard": { "value": "ease-in-out" },
+			"accelerate": { "value": "cubic-bezier(0.4, 0, 1, 1)" },
+			"decelerate": { "value": "cubic-bezier(0, 0, 0.2, 1)" }
+		}
+	}
+}

--- a/packages/tokens/src/semantic.dark.tokens.json
+++ b/packages/tokens/src/semantic.dark.tokens.json
@@ -1,0 +1,12 @@
+{
+	"color": {
+		"background": { "value": "{primitive.color.dark}" },
+		"background-faded": { "value": "{primitive.color.dark-faded}" },
+		"contrast": { "value": "{primitive.color.light}" },
+		"contrast-faded": { "value": "{primitive.color.light-faded}" },
+
+		"divider": { "value": "#3a4350" },
+		"disabled": { "value": "#6b7280" },
+		"offline": { "value": "#2c3440" }
+	}
+}

--- a/packages/tokens/src/semantic.tokens.json
+++ b/packages/tokens/src/semantic.tokens.json
@@ -1,0 +1,59 @@
+{
+	"color": {
+		"background": { "value": "{primitive.color.light}" },
+		"background-faded": { "value": "{primitive.color.light-faded}" },
+		"contrast": { "value": "{primitive.color.dark}" },
+		"contrast-faded": { "value": "{primitive.color.dark-faded}" },
+
+		"primary": { "value": "{primitive.color.blue.700}" },
+		"primary-contrast": { "value": "#fefefe" },
+		"primary-variant": { "value": "{primitive.color.cyan.300}" },
+		"primary-variant-contrast": { "value": "{primitive.color.cyan.700}" },
+
+		"secondary": { "value": "{primitive.color.purple.500}" },
+		"secondary-contrast": { "value": "{primitive.color.purple.900}" },
+		"secondary-variant": { "value": "{primitive.color.purple.300}" },
+		"secondary-variant-contrast": { "value": "{primitive.color.purple.700}" },
+
+		"transparent": { "value": "transparent" },
+		"hyperlink": { "value": "{primitive.color.blue.500}" },
+		"divider": { "value": "{primitive.color.grey.300}" },
+		"disabled": { "value": "{primitive.color.grey.500}" },
+		"offline": { "value": "{primitive.color.grey.100}" },
+
+		"error": { "value": "{primitive.color.red.500}" },
+		"error-variant": { "value": "{primitive.color.red.300}" },
+		"success": { "value": "{primitive.color.green.500}" },
+		"success-variant": { "value": "{primitive.color.green.300}" },
+		"warning": { "value": "{primitive.color.yellow.500}" },
+		"warning-variant": { "value": "{primitive.color.yellow.300}" },
+		"information": { "value": "{primitive.color.blue.300}" },
+		"information-variant": { "value": "#a6ccf1" }
+	},
+
+	"font": {
+		"family": {
+			"base": { "value": "{primitive.font.family.inter}" },
+			"serif": { "value": "{primitive.font.family.serif}" },
+			"mono": { "value": "{primitive.font.family.mono}" }
+		}
+	},
+
+	"radius": {
+		"base": { "value": "{primitive.radius.md}" }
+	},
+
+	"shadow": {
+		"sm": { "value": "0 1px 2px rgba(0, 0, 0, 0.05)" },
+		"md": { "value": "rgba(149, 157, 165, 0.2) 0px 2px 8px" },
+		"lg": { "value": "rgba(149, 157, 165, 0.2) 0px 8px 24px" }
+	},
+
+	"transition": {
+		"base": { "value": "all {primitive.duration.normal} {primitive.easing.standard}" }
+	},
+
+	"outline": {
+		"focus": { "value": "1px solid {color.hyperlink}" }
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 14.1.2
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.4(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0))(vue@3.5.34(typescript@5.9.3))
+        version: 5.2.4(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
@@ -86,19 +86,26 @@ importers:
         version: 1.99.0
       vite:
         specifier: ^6.0.0
-        version: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)
+        version: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0)
       vitest:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(sass@1.99.0)
 
   packages/ecosphere:
+    dependencies:
+      '@ecosphere/tokens':
+        specifier: workspace:*
+        version: link:../tokens
+      '@fontsource-variable/inter':
+        specifier: ^5.1.0
+        version: 5.2.8
     devDependencies:
       '@size-limit/preset-small-lib':
         specifier: ^11.1.6
         version: 11.2.0(size-limit@11.2.0)
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.2.4(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0))(vue@3.5.34(typescript@5.9.3))
+        version: 5.2.4(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
@@ -116,16 +123,25 @@ importers:
         version: 11.2.0
       vite:
         specifier: ^6.0.0
-        version: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)
+        version: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^4.3.0
-        version: 4.5.4(@types/node@22.19.19)(rollup@4.60.4)(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0))
+        version: 4.5.4(@types/node@22.19.19)(rollup@4.60.4)(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0))
       vitest:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(sass@1.99.0)
       vue:
         specifier: ^3.5.12
         version: 3.5.34(typescript@5.9.3)
+
+  packages/tokens:
+    devDependencies:
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      style-dictionary:
+        specifier: ^4.3.0
+        version: 4.4.0(tslib@2.8.1)
 
 packages:
 
@@ -152,6 +168,15 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bundled-es-modules/deepmerge@4.3.1':
+    resolution: {integrity: sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==}
+
+  '@bundled-es-modules/glob@10.4.2':
+    resolution: {integrity: sha512-740y5ofkzydsFao5EXJrGilcIL6EFEw/cmPf2uhTw9J6G1YOhiIFjNFCHdpgEiiH5VlU3G0SARSjlFlimRRSMA==}
+
+  '@bundled-es-modules/memfs@4.17.0':
+    resolution: {integrity: sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -568,6 +593,9 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fontsource-variable/inter@5.2.8':
+    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -603,6 +631,126 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jsonjoy.com/base64@1.1.2':
+    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/base64@17.67.0':
+    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@1.2.1':
+    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/buffers@17.67.0':
+    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@1.0.0':
+    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/codegen@17.67.0':
+    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-core@4.57.2':
+    resolution: {integrity: sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-fsa@4.57.2':
+    resolution: {integrity: sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-builtins@4.57.2':
+    resolution: {integrity: sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.2':
+    resolution: {integrity: sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node-utils@4.57.2':
+    resolution: {integrity: sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-node@4.57.2':
+    resolution: {integrity: sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-print@4.57.2':
+    resolution: {integrity: sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/fs-snapshot@4.57.2':
+    resolution: {integrity: sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.21.0':
+    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@17.67.0':
+    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@1.0.2':
+    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pointer@17.67.0':
+    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.9.0':
+    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@17.67.0':
+    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1133,6 +1281,13 @@ packages:
   '@vue/tsconfig@0.5.1':
     resolution: {integrity: sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==}
 
+  '@yarnpkg/lockfile@1.1.0':
+    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
+
+  '@zip.js/zip.js@2.8.26':
+    resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
+    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
+
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -1209,6 +1364,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1216,12 +1374,19 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1244,6 +1409,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bytes-iec@3.1.1:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
     engines: {node: '>= 0.8'}
@@ -1254,6 +1422,14 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -1268,6 +1444,13 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
@@ -1278,6 +1461,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1294,8 +1481,16 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
+  component-emitter@2.0.0:
+    resolution: {integrity: sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==}
+    engines: {node: '>=18'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1350,6 +1545,18 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1537,6 +1744,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1594,12 +1805,19 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  find-yarn-workspace-root@2.0.0:
+    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -1608,6 +1826,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
@@ -1629,6 +1851,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1645,10 +1871,20 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob-to-regex.js@1.2.0:
+    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -1672,6 +1908,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1705,6 +1944,10 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
+  hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1712,6 +1955,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1736,12 +1982,31 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.3:
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1751,24 +2016,51 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1829,14 +2121,29 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  klaw-sync@6.0.0:
+    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -1879,6 +2186,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1892,6 +2203,11 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  memfs@4.57.2:
+    resolution: {integrity: sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==}
+    peerDependencies:
+      tslib: '2'
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -1927,6 +2243,9 @@ packages:
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -1984,6 +2303,26 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2032,6 +2371,11 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  patch-package@8.0.1:
+    resolution: {integrity: sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==}
+    engines: {node: '>=14', npm: '>5'}
+    hasBin: true
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -2050,9 +2394,19 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  path-unified@0.2.0:
+    resolution: {integrity: sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg==}
+
+  path@0.12.7:
+    resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2099,6 +2453,10 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
@@ -2125,6 +2483,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -2132,9 +2494,16 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
+  punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -2175,6 +2544,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   rollup@4.60.4:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2188,6 +2562,13 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -2211,6 +2592,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2221,6 +2606,22 @@ packages:
 
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2234,6 +2635,10 @@ packages:
     resolution: {integrity: sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  slash@2.0.0:
+    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
+    engines: {node: '>=6'}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -2259,6 +2664,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stream@0.0.3:
+    resolution: {integrity: sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -2270,6 +2678,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2286,6 +2697,11 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-dictionary@4.4.0:
+    resolution: {integrity: sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2310,8 +2726,17 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
+  thingies@2.6.0:
+    resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -2339,6 +2764,10 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2351,11 +2780,20 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  tree-dump@1.1.0:
+    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2397,8 +2835,18 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url@0.11.4:
+    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
+    engines: {node: '>= 0.4'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.10.4:
+    resolution: {integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -2579,6 +3027,10 @@ packages:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2629,6 +3081,11 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2657,6 +3114,33 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bundled-es-modules/deepmerge@4.3.1':
+    dependencies:
+      deepmerge: 4.3.1
+
+  '@bundled-es-modules/glob@10.4.2':
+    dependencies:
+      buffer: 6.0.3
+      events: 3.3.0
+      glob: 10.5.0
+      patch-package: 8.0.1
+      path: 0.12.7
+      stream: 0.0.3
+      string_decoder: 1.3.0
+      url: 0.11.4
+
+  '@bundled-es-modules/memfs@4.17.0(tslib@2.8.1)':
+    dependencies:
+      assert: 2.1.0
+      buffer: 6.0.3
+      events: 3.3.0
+      memfs: 4.57.2(tslib@2.8.1)
+      path: 0.12.7
+      stream: 0.0.3
+      util: 0.12.5
+    transitivePeerDependencies:
+      - tslib
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -3014,6 +3498,8 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fontsource-variable/inter@5.2.8': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3047,6 +3533,133 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/buffers@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/codegen@17.67.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-core@4.57.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-fsa@4.57.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-builtins@4.57.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-to-fsa@4.57.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-fsa': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node-utils@4.57.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-node@4.57.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.2(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-print@4.57.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/fs-snapshot@4.57.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pointer@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@17.67.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
+      '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
+      tslib: 2.8.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -3433,9 +4046,9 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0))(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
-      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)
+      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@5.9.3)
 
   '@vitest/expect@2.1.9':
@@ -3622,6 +4235,10 @@ snapshots:
 
   '@vue/tsconfig@0.5.1': {}
 
+  '@yarnpkg/lockfile@1.1.0': {}
+
+  '@zip.js/zip.js@2.8.26': {}
+
   abbrev@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -3678,13 +4295,27 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
 
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -3709,6 +4340,11 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bytes-iec@3.1.1: {}
 
   cac@6.7.14: {}
@@ -3717,6 +4353,18 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -3733,6 +4381,10 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
+  change-case@5.4.4: {}
+
   chardet@2.1.1: {}
 
   check-error@2.1.3: {}
@@ -3740,6 +4392,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  ci-info@3.9.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3753,7 +4407,11 @@ snapshots:
 
   commander@10.0.1: {}
 
+  commander@12.1.0: {}
+
   compare-versions@6.1.1: {}
+
+  component-emitter@2.0.0: {}
 
   concat-map@0.0.1: {}
 
@@ -3797,6 +4455,20 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
 
@@ -4044,6 +4716,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -4094,12 +4768,20 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  find-yarn-workspace-root@2.0.0:
+    dependencies:
+      micromatch: 4.0.8
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
 
   foreground-child@3.3.1:
     dependencies:
@@ -4113,6 +4795,12 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.3
       mime-types: 2.1.35
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fs-extra@11.3.5:
     dependencies:
@@ -4136,6 +4824,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  generator-function@2.0.1: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4163,6 +4853,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-to-regex.js@1.2.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -4171,6 +4865,12 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   globals@13.24.0:
     dependencies:
@@ -4192,6 +4892,10 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -4225,6 +4929,8 @@ snapshots:
 
   human-id@4.1.3: {}
 
+  hyperdyperid@1.2.0: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -4232,6 +4938,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -4248,29 +4956,74 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.3: {}
+
+  inherits@2.0.4: {}
+
   ini@1.3.8: {}
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
 
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
 
+  is-docker@2.2.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
   is-number@7.0.0: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
   is-windows@1.0.2: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -4343,6 +5096,16 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
+  json5@2.2.3: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -4353,9 +5116,15 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonify@0.0.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  klaw-sync@6.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
 
   kolorist@1.8.0: {}
 
@@ -4394,6 +5163,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4410,6 +5181,23 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   mdurl@2.0.0: {}
+
+  memfs@4.57.2(tslib@2.8.1):
+    dependencies:
+      '@jsonjoy.com/fs-core': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.2(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
+      tslib: 2.8.1
 
   memorystream@0.3.1: {}
 
@@ -4441,6 +5229,8 @@ snapshots:
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
+
+  minimist@1.2.8: {}
 
   minipass@7.1.3: {}
 
@@ -4493,6 +5283,29 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
+  object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -4542,6 +5355,23 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  patch-package@8.0.1:
+    dependencies:
+      '@yarnpkg/lockfile': 1.1.0
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      cross-spawn: 7.0.6
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 10.1.0
+      json-stable-stringify: 1.3.0
+      klaw-sync: 6.0.0
+      minimist: 1.2.8
+      open: 7.4.2
+      semver: 7.8.0
+      slash: 2.0.0
+      tmp: 0.2.5
+      yaml: 2.9.0
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -4555,7 +5385,19 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.0
+      minipass: 7.1.3
+
   path-type@4.0.0: {}
+
+  path-unified@0.2.0: {}
+
+  path@0.12.7:
+    dependencies:
+      process: 0.11.10
+      util: 0.10.4
 
   pathe@1.1.2: {}
 
@@ -4595,6 +5437,8 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss-selector-parser@6.1.2:
     dependencies:
       cssesc: 3.0.0
@@ -4616,11 +5460,19 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  process@0.11.10: {}
+
   proto-list@1.2.4: {}
 
   punycode.js@2.3.1: {}
 
+  punycode@1.4.1: {}
+
   punycode@2.3.1: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   quansync@0.2.11: {}
 
@@ -4654,6 +5506,11 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
 
   rollup@4.60.4:
     dependencies:
@@ -4694,6 +5551,14 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
 
   sass@1.99.0:
@@ -4712,6 +5577,15 @@ snapshots:
 
   semver@7.8.0: {}
 
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -4719,6 +5593,34 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -4733,6 +5635,8 @@ snapshots:
       nanospinner: 1.2.2
       picocolors: 1.1.1
       tinyglobby: 0.2.16
+
+  slash@2.0.0: {}
 
   slash@3.0.0: {}
 
@@ -4751,6 +5655,10 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stream@0.0.3:
+    dependencies:
+      component-emitter: 2.0.0
+
   string-argv@0.3.2: {}
 
   string-width@4.2.3:
@@ -4765,6 +5673,10 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4776,6 +5688,24 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-dictionary@4.4.0(tslib@2.8.1):
+    dependencies:
+      '@bundled-es-modules/deepmerge': 4.3.1
+      '@bundled-es-modules/glob': 10.4.2
+      '@bundled-es-modules/memfs': 4.17.0(tslib@2.8.1)
+      '@zip.js/zip.js': 2.8.26
+      chalk: 5.6.2
+      change-case: 5.4.4
+      commander: 12.1.0
+      is-plain-obj: 4.1.0
+      json5: 2.2.3
+      patch-package: 8.0.1
+      path-unified: 0.2.0
+      prettier: 3.8.3
+      tinycolor2: 1.6.0
+    transitivePeerDependencies:
+      - tslib
 
   supports-color@7.2.0:
     dependencies:
@@ -4795,7 +5725,13 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  thingies@2.6.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -4816,6 +5752,8 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  tmp@0.2.5: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -4828,9 +5766,15 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-dump@1.1.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -4865,7 +5809,24 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url@0.11.4:
+    dependencies:
+      punycode: 1.4.1
+      qs: 6.15.2
+
   util-deprecate@1.0.2: {}
+
+  util@0.10.4:
+    dependencies:
+      inherits: 2.0.3
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   vite-node@2.1.9(@types/node@22.19.19)(sass@1.99.0):
     dependencies:
@@ -4885,7 +5846,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@4.5.4(@types/node@22.19.19)(rollup@4.60.4)(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)):
+  vite-plugin-dts@4.5.4(@types/node@22.19.19)(rollup@4.60.4)(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0)):
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@22.19.19)
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
@@ -4898,7 +5859,7 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)
+      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -4914,7 +5875,7 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.99.0
 
-  vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0):
+  vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(sass@1.99.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4927,6 +5888,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       sass: 1.99.0
+      yaml: 2.9.0
 
   vitest@2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(sass@1.99.0):
     dependencies:
@@ -5035,6 +5997,16 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5069,5 +6041,7 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
- Add @ecosphere/tokens package built via Style Dictionary v4 (primitive/semantic/component tiers, --ep-* prefix, light+dark CSS, SCSS, TS, JS, CJS, Tailwind preset).
- Refactor vue-ecosphere SCSS to alias legacy --color-*/--font-* vars onto the new tokens (full back-compat, no component edits required).
- Add <EpConfigProvider> for theme/size/locale via provide/inject, with runtime prefers-color-scheme listener.
- setTheme() now drives data-theme on <html>; setColors/setFonts are deprecated in favour of overriding --ep-color-* / --ep-font-family-*.