### PR TITLE
feat(m2)!: navigation finale — Tabs, Menu, Sidebar, Navbar, Breadcrum…

### DIFF
--- a/.changeset/m2-component-hardening.md
+++ b/.changeset/m2-component-hardening.md
@@ -1,0 +1,78 @@
+---
+"vue-ecosphere": major
+---
+
+M2 Component Hardening — full milestone, breaking changes across all components.
+
+The M2 milestone rewrites the design system's component layer on top of the
+M0 + M1 foundations. Every component now ships with: strict TypeScript prop
+types, ARIA-first markup, full keyboard navigation, axe-core verified
+accessibility, plain-CSS using `--ep-*` tokens (no SCSS), unified sizing
+(`xs|sm|md|lg|xl`), and unified `EpHue` palette.
+
+### Breaking changes (consolidated)
+
+- **v-model rename**: every form / interactive component now uses
+  `v-model:value` instead of `v-model:modelValue`. Affected: `EpInput`,
+  `EpInputNumber`, `EpTextarea`, `EpSelect`, `EpRadio`, `EpRadioGroup`,
+  `EpCheckbox`, `EpCheckboxGroup`, `EpSwitch`, `EpChoiceChips`, `EpColorPicker`,
+  `EpTabNavigation`, `EpStepper`, `EpSidebar` (collapsed).
+- **`EpDropdown` and `EpSearchDropdown` removed**. Use `EpSelect` instead:
+  it supports single + multiple selection, searchable filtering, prepend /
+  append slots, and primitive (string/number/boolean) options.
+- **Stepper**: `current` prop renamed to `value` (now v-model-able);
+  `responsive` defaults to `true`; new `clickable`, `progressDots`, `state`
+  props; emits `change` alongside `update:value`.
+- **Breadcrumb**: `options` prop renamed to `items`; `outline` prop renamed
+  to `bordered`; emits a typed `select` event; supports `separator` and
+  `item` scoped slots; uses proper `<nav><ol>` landmark semantics.
+- **Tag, ChoiceChips**: `outline` prop renamed to `bordered`.
+- **Tabs**: `EpTabNavigation` now uses `value` (v-model) instead of
+  `active`; new `variant: "underline" | "filled" | "pills"`, `closable`,
+  `addable`, `lazy`, `vertical` props; emits `add` and `close` events;
+  arrow-key / Home / End keyboard navigation following the WAI-ARIA tabs
+  pattern.
+- **Menu, Sidebar**: rewritten on the new `MenuItem` primitive (proper
+  `role="menu"` + `role="menuitem"`, `aria-expanded` for submenus,
+  `aria-current="page"` for active items). `EpSidebar` now supports
+  `collapsible`, `responsive` (mobile drawer via `<Teleport>`), `header` +
+  `footer` slots, and `v-model:collapsed`.
+- **Navbar**: `EpNavbar` now uses `<header role="banner">` + `<nav>`
+  landmarks; new `branding`, `affix`, `bordered`, `hue`, `theme` props;
+  three slots (`brand`, default centre area, `end`).
+- **Sizing**: `EpSize` is unified to `"xs" | "sm" | "md" | "lg" | "xl"`
+  everywhere; pass `size` directly or fall back to `useEpConfig().size`.
+- **Hue**: `EpHue` is unified to `primary | primary-variant | secondary |
+  secondary-variant | error | success | warning | information`; legacy
+  per-component palette tokens were removed.
+
+### Internal
+
+- `sass` removed from `vue-ecosphere`'s devDependencies. The package's
+  SFCs no longer use `<style lang="scss">`; all styling is plain CSS over
+  design tokens. (`apps/docs` keeps its own `sass` dep transitionally.)
+- `framework.scss` is no longer exported by the package (`./styles/framework.scss`
+  exports entry removed). The legacy SCSS partials remain in source for
+  the docs SPA's transitional usage only.
+- The `**/*.scss` entry was removed from the package's `sideEffects` list.
+- New shared test helper `expectNoA11yViolations()` ships axe-core based
+  a11y assertions used by 23 component spec files (189 unit tests total).
+
+### Migration
+
+```diff
+- <EpDropdown v-model:modelValue="value" :options="opts" />
++ <EpSelect v-model:value="value" :options="opts" />
+
+- <EpBreadcrumb :options="trail" outline />
++ <EpBreadcrumb :items="trail" bordered />
+
+- <EpStepper :current="n" :steps="steps" />
++ <EpStepper v-model:value="n" :steps="steps" />
+
+- <EpTabNavigation :active="t" :options="opts" />
++ <EpTabNavigation v-model:value="t" :options="opts" />
+
+- <EpTag outline>...
++ <EpTag bordered>...
+```

--- a/packages/ecosphere/package.json
+++ b/packages/ecosphere/package.json
@@ -18,8 +18,7 @@
 	},
 	"type": "module",
 	"sideEffects": [
-		"**/*.css",
-		"**/*.scss"
+		"**/*.css"
 	],
 	"files": [
 		"dist"
@@ -34,7 +33,6 @@
 			"require": "./dist/vue-ecosphere.umd.cjs"
 		},
 		"./styles": "./dist/vue-ecosphere.css",
-		"./styles/framework.scss": "./src/styles/framework.scss",
 		"./package.json": "./package.json"
 	},
 	"engines": {
@@ -63,7 +61,6 @@
 		"@vue/tsconfig": "^0.5.1",
 		"axe-core": "^4.11.4",
 		"jsdom": "^25.0.1",
-		"sass": "^1.80.6",
 		"size-limit": "^11.1.6",
 		"vite": "^6.0.0",
 		"vite-plugin-dts": "^4.3.0",

--- a/packages/ecosphere/src/call-to-action/ButtonComponent.story.vue
+++ b/packages/ecosphere/src/call-to-action/ButtonComponent.story.vue
@@ -67,7 +67,11 @@ const sizes: EpSize[] = ["xs", "sm", "md", "lg", "xl"];
 		</Variant>
 
 		<Variant title="As link">
-			<ButtonComponent label="Open docs" href="https://example.com" target="_blank" />
+			<ButtonComponent
+				label="Open docs"
+				href="https://example.com"
+				target="_blank"
+			/>
 		</Variant>
 	</Story>
 </template>

--- a/packages/ecosphere/src/call-to-action/ButtonComponent.vue
+++ b/packages/ecosphere/src/call-to-action/ButtonComponent.vue
@@ -16,7 +16,11 @@
 		:type="tag === 'button' ? htmlType : undefined"
 		:href="tag === 'a' ? href : undefined"
 		:target="tag === 'a' ? target : undefined"
-		:rel="tag === 'a' && target === '_blank' ? 'noopener noreferrer' : undefined"
+		:rel="
+			tag === 'a' && target === '_blank'
+				? 'noopener noreferrer'
+				: undefined
+		"
 		:disabled="tag === 'button' ? isDisabled : undefined"
 		:aria-disabled="isDisabled ? 'true' : undefined"
 		:aria-busy="loading ? 'true' : undefined"
@@ -122,7 +126,7 @@ const size = useEpSize(() => props.size);
 const tag = computed<"button" | "a">(() => (props.href ? "a" : "button"));
 const isDisabled = computed(() => props.disabled || props.loading);
 const effectiveHue = computed<EpHue>(() =>
-	props.danger ? "error" : props.hue,
+	props.danger ? "error" : props.hue
 );
 const hasIcon = computed(() => Boolean(props.icon || slots.icon));
 const hasLabel = computed(() => Boolean(props.label || slots.default));

--- a/packages/ecosphere/src/call-to-action/LinkComponent.story.vue
+++ b/packages/ecosphere/src/call-to-action/LinkComponent.story.vue
@@ -7,7 +7,11 @@ import LinkComponent from "./LinkComponent.vue";
 			<LinkComponent label="Go to docs" href="#" />
 		</Variant>
 		<Variant title="With icon">
-			<LinkComponent label="External" href="#" icon="ri-external-link-line" />
+			<LinkComponent
+				label="External"
+				href="#"
+				icon="ri-external-link-line"
+			/>
 		</Variant>
 		<Variant title="Disabled">
 			<LinkComponent label="Disabled" href="#" disabled />

--- a/packages/ecosphere/src/call-to-action/__tests__/ButtonComponent.spec.ts
+++ b/packages/ecosphere/src/call-to-action/__tests__/ButtonComponent.spec.ts
@@ -43,7 +43,9 @@ describe("EpButton", () => {
 	});
 
 	it("block applies full-width modifier", () => {
-		const w = mount(ButtonComponent, { props: { label: "x", block: true } });
+		const w = mount(ButtonComponent, {
+			props: { label: "x", block: true },
+		});
 		expect(w.classes()).toContain("ep-button--block");
 	});
 
@@ -85,7 +87,11 @@ describe("EpButton", () => {
 
 	it("href with target=_blank adds rel noopener", () => {
 		const w = mount(ButtonComponent, {
-			props: { label: "Out", href: "https://x.example", target: "_blank" },
+			props: {
+				label: "Out",
+				href: "https://x.example",
+				target: "_blank",
+			},
 		});
 		expect(w.attributes("target")).toBe("_blank");
 		expect(w.attributes("rel")).toBe("noopener noreferrer");

--- a/packages/ecosphere/src/composables/useEpConfig.ts
+++ b/packages/ecosphere/src/composables/useEpConfig.ts
@@ -13,7 +13,7 @@ export function useEpConfig(): EpConfig {
 		theme: ref<theme>("auto") as Ref<theme>,
 		size: ref<EpSize>("md"),
 		locale: ref(
-			typeof navigator !== "undefined" ? navigator.language : "en",
+			typeof navigator !== "undefined" ? navigator.language : "en"
 		),
 	};
 }

--- a/packages/ecosphere/src/composables/useEpSize.ts
+++ b/packages/ecosphere/src/composables/useEpSize.ts
@@ -1,4 +1,9 @@
-import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from "vue";
+import {
+	computed,
+	type ComputedRef,
+	type MaybeRefOrGetter,
+	toValue,
+} from "vue";
 import type { EpSize } from "../general/config";
 import { useEpConfig } from "./useEpConfig";
 
@@ -7,7 +12,7 @@ import { useEpConfig } from "./useEpConfig";
  * context, then `"md"`.
  */
 export function useEpSize(
-	propSize?: MaybeRefOrGetter<EpSize | undefined>,
+	propSize?: MaybeRefOrGetter<EpSize | undefined>
 ): ComputedRef<EpSize> {
 	const config = useEpConfig();
 	return computed<EpSize>(() => {

--- a/packages/ecosphere/src/data-entry/CheckboxField.vue
+++ b/packages/ecosphere/src/data-entry/CheckboxField.vue
@@ -20,7 +20,9 @@
 			:name="name"
 			:value="nativeValueAttr"
 			:aria-label="ariaLabel || label"
-			:aria-checked="indeterminate ? 'mixed' : isChecked ? 'true' : 'false'"
+			:aria-checked="
+				indeterminate ? 'mixed' : isChecked ? 'true' : 'false'
+			"
 			:aria-describedby="describedBy"
 			@change="onChange"
 			@focus="emit('focus', $event)"
@@ -114,19 +116,25 @@ const isArrayMode = computed(() => Array.isArray(props.value));
 
 const isChecked = computed<boolean>(() => {
 	if (Array.isArray(props.value)) {
-		return props.nativeValue !== undefined && props.value.includes(props.nativeValue);
+		return (
+			props.nativeValue !== undefined &&
+			props.value.includes(props.nativeValue)
+		);
 	}
 	return !!props.value;
 });
 
 const nativeValueAttr = computed(() =>
-	props.nativeValue === undefined ? undefined : String(props.nativeValue),
+	props.nativeValue === undefined ? undefined : String(props.nativeValue)
 );
 
 function onChange(e: Event) {
 	if (props.disabled) return;
 	const next: CheckboxValue = isArrayMode.value
-		? toggleInArray(props.value as (string | number | boolean)[], props.nativeValue)
+		? toggleInArray(
+				props.value as (string | number | boolean)[],
+				props.nativeValue
+			)
 		: !isChecked.value;
 	emit("update:value", next);
 	emit("change", next, e);
@@ -253,8 +261,14 @@ watchPostEffect(() => {
 	}
 	&--checked.ep-checkbox--secondary-variant &__box,
 	&--indeterminate.ep-checkbox--secondary-variant &__box {
-		background: var(--ep-color-secondary-variant, var(--ep-color-secondary));
-		border-color: var(--ep-color-secondary-variant, var(--ep-color-secondary));
+		background: var(
+			--ep-color-secondary-variant,
+			var(--ep-color-secondary)
+		);
+		border-color: var(
+			--ep-color-secondary-variant,
+			var(--ep-color-secondary)
+		);
 		color: var(--ep-color-contrast, #fff);
 	}
 	&--checked.ep-checkbox--information &__box,

--- a/packages/ecosphere/src/data-entry/CheckboxGroup.vue
+++ b/packages/ecosphere/src/data-entry/CheckboxGroup.vue
@@ -67,11 +67,7 @@ export interface CheckboxOption {
 	hidden?: boolean;
 }
 
-export type CheckboxOptionLike =
-	| CheckboxOption
-	| string
-	| number
-	| boolean;
+export type CheckboxOptionLike = CheckboxOption | string | number | boolean;
 
 export type CheckboxGroupAlignment = "flex" | "vertical" | "grid";
 export type DataEntryState = "default" | "error" | "warning" | "success";
@@ -117,12 +113,16 @@ const assistId = useEpId("ep-checkbox-group-assist");
 
 const normalizedOptions = computed<CheckboxOption[]>(() =>
 	props.options
-		.map((opt): CheckboxOption =>
-			typeof opt === "object" && opt !== null && "label" in opt
-				? (opt as CheckboxOption)
-				: { label: String(opt), value: opt as string | number | boolean },
+		.map(
+			(opt): CheckboxOption =>
+				typeof opt === "object" && opt !== null && "label" in opt
+					? (opt as CheckboxOption)
+					: {
+							label: String(opt),
+							value: opt as string | number | boolean,
+						}
 		)
-		.filter((opt) => !opt.hidden),
+		.filter((opt) => !opt.hidden)
 );
 
 function handleUpdate(next: boolean | CheckboxGroupValue) {

--- a/packages/ecosphere/src/data-entry/ChoiceChips.story.vue
+++ b/packages/ecosphere/src/data-entry/ChoiceChips.story.vue
@@ -17,13 +17,31 @@ const sizes = [
 			<ChoiceChips v-model:value="single" label="Size" :options="sizes" />
 		</Variant>
 		<Variant title="Multiple">
-			<ChoiceChips v-model:value="multi" label="Sizes" :options="sizes" multiple hue="success" />
+			<ChoiceChips
+				v-model:value="multi"
+				label="Sizes"
+				:options="sizes"
+				multiple
+				hue="success"
+			/>
 		</Variant>
 		<Variant title="Bordered">
-			<ChoiceChips v-model:value="single" label="Size" :options="sizes" bordered hue="information" />
+			<ChoiceChips
+				v-model:value="single"
+				label="Size"
+				:options="sizes"
+				bordered
+				hue="information"
+			/>
 		</Variant>
 		<Variant title="Grid">
-			<ChoiceChips v-model:value="multi" label="Tags" :options="sizes" multiple alignment="grid" />
+			<ChoiceChips
+				v-model:value="multi"
+				label="Tags"
+				:options="sizes"
+				multiple
+				alignment="grid"
+			/>
 		</Variant>
 	</Story>
 </template>

--- a/packages/ecosphere/src/data-entry/ChoiceChips.vue
+++ b/packages/ecosphere/src/data-entry/ChoiceChips.vue
@@ -11,7 +11,9 @@
 			:id="labelId"
 			class="ep-choice-chips__label"
 			:class="state !== 'default' && `ep-choice-chips__label--${state}`"
-		>{{ label }}</div>
+		>
+			{{ label }}
+		</div>
 		<div
 			class="ep-choice-chips__options"
 			:class="`ep-choice-chips__options--${alignment}`"
@@ -25,8 +27,11 @@
 					`ep-choice-chips__chip--${size}`,
 					{
 						'ep-choice-chips__chip--active': isSelected(opt.value),
-						'ep-choice-chips__chip--disabled': opt.disabled || disabled,
-						[`ep-choice-chips__chip--${hue}`]: isSelected(opt.value),
+						'ep-choice-chips__chip--disabled':
+							opt.disabled || disabled,
+						[`ep-choice-chips__chip--${hue}`]: isSelected(
+							opt.value
+						),
 						'ep-choice-chips__chip--bordered': bordered,
 					},
 				]"
@@ -34,7 +39,11 @@
 				:aria-pressed="isSelected(opt.value) ? 'true' : 'false'"
 				@click="toggle(opt)"
 			>
-				<slot name="chip" :option="opt" :selected="isSelected(opt.value)">
+				<slot
+					name="chip"
+					:option="opt"
+					:selected="isSelected(opt.value)"
+				>
 					{{ opt.label }}
 				</slot>
 			</button>
@@ -45,12 +54,16 @@
 			class="ep-choice-chips__alert"
 			:class="`ep-choice-chips__alert--${state}`"
 			role="alert"
-		>{{ alertMessage }}</div>
+		>
+			{{ alertMessage }}
+		</div>
 		<div
 			v-else-if="assistiveText"
 			:id="describedById"
 			class="ep-choice-chips__assistive"
-		>{{ assistiveText }}</div>
+		>
+			{{ assistiveText }}
+		</div>
 	</div>
 </template>
 
@@ -62,10 +75,7 @@ import type { EpSize } from "../general/config";
 import type { EpHue } from "../utilities/types/shared";
 
 export type ChoicePrimitive = string | number | boolean;
-export type ChoiceChipsValue =
-	| ChoicePrimitive
-	| ChoicePrimitive[]
-	| null;
+export type ChoiceChipsValue = ChoicePrimitive | ChoicePrimitive[] | null;
 
 export interface ChoiceOption {
 	label: string;
@@ -125,12 +135,14 @@ function normalize(o: ChoiceOptionLike): ChoiceOption {
 }
 
 const normalizedOptions = computed<ChoiceOption[]>(() =>
-	(props.options || []).map(normalize).filter((o) => !o.hidden),
+	(props.options || []).map(normalize).filter((o) => !o.hidden)
 );
 
 const valuesArray = computed<ChoicePrimitive[]>(() => {
 	if (props.value == null) return [];
-	return Array.isArray(props.value) ? props.value : [props.value as ChoicePrimitive];
+	return Array.isArray(props.value)
+		? props.value
+		: [props.value as ChoicePrimitive];
 });
 
 function isSelected(v: ChoicePrimitive): boolean {
@@ -167,9 +179,15 @@ function toggle(opt: ChoiceOption) {
 		font-size: 0.875rem;
 		font-weight: 500;
 
-		&--error { color: var(--ep-color-error); }
-		&--warning { color: var(--ep-color-warning); }
-		&--success { color: var(--ep-color-success); }
+		&--error {
+			color: var(--ep-color-error);
+		}
+		&--warning {
+			color: var(--ep-color-warning);
+		}
+		&--success {
+			color: var(--ep-color-success);
+		}
 	}
 
 	&__options {
@@ -204,18 +222,36 @@ function toggle(opt: ChoiceOption) {
 		border-radius: var(--ep-radius-pill, 999px);
 		background: var(--ep-color-surface-alt, rgba(0, 0, 0, 0.04));
 		color: var(--ep-color-text, currentColor);
-		transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+		transition:
+			background 0.15s ease,
+			color 0.15s ease,
+			border-color 0.15s ease;
 
 		&--bordered {
 			border: 1px solid var(--ep-color-border, currentColor);
 			background: transparent;
 		}
 
-		&--xs { padding: 0.125rem 0.5rem; font-size: 0.6875rem; }
-		&--sm { padding: 0.1875rem 0.625rem; font-size: 0.75rem; }
-		&--md { padding: 0.25rem 0.75rem; font-size: 0.8125rem; }
-		&--lg { padding: 0.375rem 0.875rem; font-size: 0.9375rem; }
-		&--xl { padding: 0.5rem 1rem; font-size: 1rem; }
+		&--xs {
+			padding: 0.125rem 0.5rem;
+			font-size: 0.6875rem;
+		}
+		&--sm {
+			padding: 0.1875rem 0.625rem;
+			font-size: 0.75rem;
+		}
+		&--md {
+			padding: 0.25rem 0.75rem;
+			font-size: 0.8125rem;
+		}
+		&--lg {
+			padding: 0.375rem 0.875rem;
+			font-size: 0.9375rem;
+		}
+		&--xl {
+			padding: 0.5rem 1rem;
+			font-size: 1rem;
+		}
 
 		&:hover:not(.ep-choice-chips__chip--disabled) {
 			background: var(--ep-color-surface-hover, rgba(0, 0, 0, 0.06));
@@ -237,14 +273,46 @@ function toggle(opt: ChoiceOption) {
 			border-color: var(--ep-color-primary);
 		}
 
-		&--active.ep-choice-chips__chip--primary { background: var(--ep-color-primary); border-color: var(--ep-color-primary); color: var(--ep-color-on-primary, #fff); }
-		&--active.ep-choice-chips__chip--primary-variant { background: var(--ep-color-primary-variant); border-color: var(--ep-color-primary-variant); color: var(--ep-color-on-primary, #fff); }
-		&--active.ep-choice-chips__chip--secondary { background: var(--ep-color-secondary); border-color: var(--ep-color-secondary); color: var(--ep-color-on-secondary, #fff); }
-		&--active.ep-choice-chips__chip--secondary-variant { background: var(--ep-color-secondary-variant); border-color: var(--ep-color-secondary-variant); color: var(--ep-color-on-secondary, #fff); }
-		&--active.ep-choice-chips__chip--information { background: var(--ep-color-information); border-color: var(--ep-color-information); color: #fff; }
-		&--active.ep-choice-chips__chip--success { background: var(--ep-color-success); border-color: var(--ep-color-success); color: #fff; }
-		&--active.ep-choice-chips__chip--warning { background: var(--ep-color-warning); border-color: var(--ep-color-warning); color: #fff; }
-		&--active.ep-choice-chips__chip--error { background: var(--ep-color-error); border-color: var(--ep-color-error); color: #fff; }
+		&--active.ep-choice-chips__chip--primary {
+			background: var(--ep-color-primary);
+			border-color: var(--ep-color-primary);
+			color: var(--ep-color-on-primary, #fff);
+		}
+		&--active.ep-choice-chips__chip--primary-variant {
+			background: var(--ep-color-primary-variant);
+			border-color: var(--ep-color-primary-variant);
+			color: var(--ep-color-on-primary, #fff);
+		}
+		&--active.ep-choice-chips__chip--secondary {
+			background: var(--ep-color-secondary);
+			border-color: var(--ep-color-secondary);
+			color: var(--ep-color-on-secondary, #fff);
+		}
+		&--active.ep-choice-chips__chip--secondary-variant {
+			background: var(--ep-color-secondary-variant);
+			border-color: var(--ep-color-secondary-variant);
+			color: var(--ep-color-on-secondary, #fff);
+		}
+		&--active.ep-choice-chips__chip--information {
+			background: var(--ep-color-information);
+			border-color: var(--ep-color-information);
+			color: #fff;
+		}
+		&--active.ep-choice-chips__chip--success {
+			background: var(--ep-color-success);
+			border-color: var(--ep-color-success);
+			color: #fff;
+		}
+		&--active.ep-choice-chips__chip--warning {
+			background: var(--ep-color-warning);
+			border-color: var(--ep-color-warning);
+			color: #fff;
+		}
+		&--active.ep-choice-chips__chip--error {
+			background: var(--ep-color-error);
+			border-color: var(--ep-color-error);
+			color: #fff;
+		}
 	}
 
 	&__assistive {
@@ -254,9 +322,15 @@ function toggle(opt: ChoiceOption) {
 
 	&__alert {
 		font-size: 0.75rem;
-		&--error { color: var(--ep-color-error); }
-		&--warning { color: var(--ep-color-warning); }
-		&--success { color: var(--ep-color-success); }
+		&--error {
+			color: var(--ep-color-error);
+		}
+		&--warning {
+			color: var(--ep-color-warning);
+		}
+		&--success {
+			color: var(--ep-color-success);
+		}
 	}
 }
 </style>

--- a/packages/ecosphere/src/data-entry/ColorPicker.story.vue
+++ b/packages/ecosphere/src/data-entry/ColorPicker.story.vue
@@ -16,7 +16,14 @@ const c = ref<string | null>("#3366ff");
 			<ColorPicker
 				v-model:value="c"
 				label="Theme"
-				:presets="['#ff5e57', '#ffa600', '#52c41a', '#1890ff', '#722ed1', '#000000']"
+				:presets="[
+					'#ff5e57',
+					'#ffa600',
+					'#52c41a',
+					'#1890ff',
+					'#722ed1',
+					'#000000',
+				]"
 			/>
 		</Variant>
 		<Variant title="Clearable">

--- a/packages/ecosphere/src/data-entry/ColorPicker.vue
+++ b/packages/ecosphere/src/data-entry/ColorPicker.vue
@@ -15,7 +15,8 @@
 			:id="labelId"
 			class="ep-color-picker__label"
 			:class="state !== 'default' && `ep-color-picker__label--${state}`"
-		>{{ label }}</label>
+			>{{ label }}</label
+		>
 		<div ref="rootRef" class="ep-color-picker__wrapper">
 			<button
 				:id="triggerId"
@@ -33,7 +34,9 @@
 				<slot name="trigger" :value="displayValue" :open="isOpen">
 					<span
 						class="ep-color-picker__swatch"
-						:style="{ backgroundColor: displayValue || 'transparent' }"
+						:style="{
+							backgroundColor: displayValue || 'transparent',
+						}"
 						aria-hidden
 					>
 						<span
@@ -41,7 +44,9 @@
 							class="ep-color-picker__swatch-empty"
 						></span>
 					</span>
-					<span class="ep-color-picker__text">{{ formattedDisplay }}</span>
+					<span class="ep-color-picker__text">{{
+						formattedDisplay
+					}}</span>
 				</slot>
 			</button>
 
@@ -92,7 +97,12 @@
 								class="ep-color-picker__hue"
 								:value="hue"
 								aria-label="Hue"
-								@input="onHueInput(($event.target as HTMLInputElement).valueAsNumber)"
+								@input="
+									onHueInput(
+										($event.target as HTMLInputElement)
+											.valueAsNumber
+									)
+								"
 							/>
 							<input
 								v-if="alpha"
@@ -103,25 +113,37 @@
 								class="ep-color-picker__alpha"
 								:value="Math.round(alphaValue * 100)"
 								:style="{
-									'--ep-color-picker-alpha-bg':
-										`linear-gradient(to right, transparent, ${previewSolid})`,
+									'--ep-color-picker-alpha-bg': `linear-gradient(to right, transparent, ${previewSolid})`,
 								}"
 								aria-label="Alpha"
-								@input="onAlphaInput(($event.target as HTMLInputElement).valueAsNumber / 100)"
+								@input="
+									onAlphaInput(
+										($event.target as HTMLInputElement)
+											.valueAsNumber / 100
+									)
+								"
 							/>
 						</div>
 					</div>
 
-					<div v-if="formatOptions.length > 1" class="ep-color-picker__formats">
+					<div
+						v-if="formatOptions.length > 1"
+						class="ep-color-picker__formats"
+					>
 						<button
 							v-for="f in formatOptions"
 							:key="f"
 							type="button"
 							class="ep-color-picker__format-btn"
-							:class="{ 'ep-color-picker__format-btn--active': format === f }"
+							:class="{
+								'ep-color-picker__format-btn--active':
+									format === f,
+							}"
 							:aria-pressed="format === f ? 'true' : 'false'"
 							@click="format = f"
-						>{{ f.toUpperCase() }}</button>
+						>
+							{{ f.toUpperCase() }}
+						</button>
 					</div>
 
 					<div class="ep-color-picker__input-row">
@@ -135,7 +157,10 @@
 						/>
 					</div>
 
-					<div v-if="presets && presets.length" class="ep-color-picker__presets">
+					<div
+						v-if="presets && presets.length"
+						class="ep-color-picker__presets"
+					>
 						<button
 							v-for="p in presets"
 							:key="p"
@@ -153,12 +178,16 @@
 							type="button"
 							class="ep-color-picker__action ep-color-picker__action--ghost"
 							@click="clear"
-						>{{ clearLabel }}</button>
+						>
+							{{ clearLabel }}
+						</button>
 						<button
 							type="button"
 							class="ep-color-picker__action"
 							@click="close"
-						>{{ doneLabel }}</button>
+						>
+							{{ doneLabel }}
+						</button>
 					</div>
 				</div>
 			</Transition>
@@ -169,12 +198,16 @@
 			class="ep-color-picker__alert"
 			:class="`ep-color-picker__alert--${state}`"
 			role="alert"
-		>{{ alertMessage }}</div>
+		>
+			{{ alertMessage }}
+		</div>
 		<div
 			v-else-if="assistiveText"
 			:id="describedById"
 			class="ep-color-picker__assistive"
-		>{{ assistiveText }}</div>
+		>
+			{{ assistiveText }}
+		</div>
 	</div>
 </template>
 
@@ -249,9 +282,18 @@ const textInput = ref("");
 
 const displayValue = computed(() => props.value || "");
 
-const previewSolid = computed(() => hsvToHex(hue.value, saturation.value, value.value));
+const previewSolid = computed(() =>
+	hsvToHex(hue.value, saturation.value, value.value)
+);
 const currentColorString = computed(() =>
-	formatColor(hue.value, saturation.value, value.value, alphaValue.value, format.value, props.alpha),
+	formatColor(
+		hue.value,
+		saturation.value,
+		value.value,
+		alphaValue.value,
+		format.value,
+		props.alpha
+	)
 );
 
 const formattedDisplay = computed(() => {
@@ -260,13 +302,17 @@ const formattedDisplay = computed(() => {
 });
 
 // HSV ↔ HEX / RGB
-function clamp01(x: number) { return Math.min(1, Math.max(0, x)); }
+function clamp01(x: number) {
+	return Math.min(1, Math.max(0, x));
+}
 
 function hsvToRgb(h: number, s: number, v: number) {
 	const c = v * s;
 	const hp = (h % 360) / 60;
 	const x = c * (1 - Math.abs((hp % 2) - 1));
-	let r = 0, g = 0, b = 0;
+	let r = 0,
+		g = 0,
+		b = 0;
 	if (hp >= 0 && hp < 1) [r, g, b] = [c, x, 0];
 	else if (hp < 2) [r, g, b] = [x, c, 0];
 	else if (hp < 3) [r, g, b] = [0, c, x];
@@ -282,8 +328,11 @@ function hsvToRgb(h: number, s: number, v: number) {
 }
 
 function rgbToHsv(r: number, g: number, b: number) {
-	r /= 255; g /= 255; b /= 255;
-	const max = Math.max(r, g, b), min = Math.min(r, g, b);
+	r /= 255;
+	g /= 255;
+	b /= 255;
+	const max = Math.max(r, g, b),
+		min = Math.min(r, g, b);
 	const d = max - min;
 	let h = 0;
 	if (d === 0) h = 0;
@@ -302,7 +351,9 @@ function hsvToHex(h: number, s: number, v: number) {
 	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
-function parseColor(input: string): { h: number; s: number; v: number; a: number } | null {
+function parseColor(
+	input: string
+): { h: number; s: number; v: number; a: number } | null {
 	if (!input) return null;
 	const s = input.trim();
 	// hex
@@ -310,7 +361,10 @@ function parseColor(input: string): { h: number; s: number; v: number; a: number
 	if (m) {
 		let hex = m[1];
 		if (hex.length === 3 || hex.length === 4) {
-			hex = hex.split("").map((c) => c + c).join("");
+			hex = hex
+				.split("")
+				.map((c) => c + c)
+				.join("");
 		}
 		const r = parseInt(hex.slice(0, 2), 16);
 		const g = parseInt(hex.slice(2, 4), 16);
@@ -320,14 +374,20 @@ function parseColor(input: string): { h: number; s: number; v: number; a: number
 		return { ...hsv, a };
 	}
 	// rgb / rgba
-	m = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(s);
+	m =
+		/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(
+			s
+		);
 	if (m) {
 		const hsv = rgbToHsv(+m[1], +m[2], +m[3]);
 		const a = m[4] === undefined ? 1 : Math.min(1, Math.max(0, +m[4]));
 		return { ...hsv, a };
 	}
 	// hsl / hsla
-	m = /^hsla?\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(s);
+	m =
+		/^hsla?\(\s*(\d+)\s*,\s*(\d+)%\s*,\s*(\d+)%\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(
+			s
+		);
 	if (m) {
 		const h = +m[1];
 		const sl = +m[2] / 100;
@@ -341,27 +401,41 @@ function parseColor(input: string): { h: number; s: number; v: number; a: number
 	return null;
 }
 
-function formatColor(h: number, s: number, v: number, a: number, fmt: ColorFormat, includeAlpha: boolean) {
+function formatColor(
+	h: number,
+	s: number,
+	v: number,
+	a: number,
+	fmt: ColorFormat,
+	includeAlpha: boolean
+) {
 	if (fmt === "hex") {
 		const hex = hsvToHex(h, s, v);
 		if (includeAlpha) {
-			const ah = Math.round(a * 255).toString(16).padStart(2, "0");
+			const ah = Math.round(a * 255)
+				.toString(16)
+				.padStart(2, "0");
 			return `${hex}${ah}`;
 		}
 		return hex;
 	}
 	const { r, g, b } = hsvToRgb(h, s, v);
 	if (fmt === "rgb") {
-		return includeAlpha ? `rgba(${r}, ${g}, ${b}, ${+a.toFixed(2)})` : `rgb(${r}, ${g}, ${b})`;
+		return includeAlpha
+			? `rgba(${r}, ${g}, ${b}, ${+a.toFixed(2)})`
+			: `rgb(${r}, ${g}, ${b})`;
 	}
 	// hsl
-	const max = v, min = v * (1 - s);
+	const max = v,
+		min = v * (1 - s);
 	const l = (max + min) / 2;
 	const sl = l === 0 || l === 1 ? 0 : (max - l) / Math.min(l, 1 - l);
 	const H = Math.round(h);
 	const S = Math.round(sl * 100);
 	const L = Math.round(l * 100);
-	return includeAlpha ? `hsla(${H}, ${S}%, ${L}%, ${+a.toFixed(2)})` : `hsl(${H}, ${S}%, ${L}%)`;
+	return includeAlpha
+		? `hsla(${H}, ${S}%, ${L}%, ${+a.toFixed(2)})`
+		: `hsl(${H}, ${S}%, ${L}%)`;
 }
 
 // Sync external value → internal HSV
@@ -500,8 +574,12 @@ onBeforeUnmount(() => {
 	window.removeEventListener("pointerup", onPaletteUp);
 });
 
-function focus() { triggerRef.value?.focus(); }
-function blur() { triggerRef.value?.blur(); }
+function focus() {
+	triggerRef.value?.focus();
+}
+function blur() {
+	triggerRef.value?.blur();
+}
 defineExpose({ focus, blur, open, close });
 </script>
 
@@ -517,9 +595,15 @@ defineExpose({ focus, blur, open, close });
 		font-size: 0.875rem;
 		font-weight: 500;
 
-		&--error { color: var(--ep-color-error); }
-		&--warning { color: var(--ep-color-warning); }
-		&--success { color: var(--ep-color-success); }
+		&--error {
+			color: var(--ep-color-error);
+		}
+		&--warning {
+			color: var(--ep-color-warning);
+		}
+		&--success {
+			color: var(--ep-color-success);
+		}
 	}
 
 	&__wrapper {
@@ -548,11 +632,26 @@ defineExpose({ focus, blur, open, close });
 		}
 	}
 
-	&--xs &__trigger { font-size: 0.75rem; padding: 0.125rem 0.375rem; }
-	&--sm &__trigger { font-size: 0.8125rem; padding: 0.1875rem 0.4375rem; }
-	&--md &__trigger { font-size: 0.9375rem; padding: 0.25rem 0.5rem; }
-	&--lg &__trigger { font-size: 1rem; padding: 0.375rem 0.625rem; }
-	&--xl &__trigger { font-size: 1.125rem; padding: 0.5rem 0.75rem; }
+	&--xs &__trigger {
+		font-size: 0.75rem;
+		padding: 0.125rem 0.375rem;
+	}
+	&--sm &__trigger {
+		font-size: 0.8125rem;
+		padding: 0.1875rem 0.4375rem;
+	}
+	&--md &__trigger {
+		font-size: 0.9375rem;
+		padding: 0.25rem 0.5rem;
+	}
+	&--lg &__trigger {
+		font-size: 1rem;
+		padding: 0.375rem 0.625rem;
+	}
+	&--xl &__trigger {
+		font-size: 1.125rem;
+		padding: 0.5rem 0.75rem;
+	}
 
 	&__swatch {
 		display: inline-block;
@@ -562,12 +661,17 @@ defineExpose({ focus, blur, open, close });
 		border: 1px solid var(--ep-color-border, rgba(0, 0, 0, 0.15));
 		position: relative;
 		overflow: hidden;
-		background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
+		background-image:
+			linear-gradient(45deg, #ccc 25%, transparent 25%),
 			linear-gradient(-45deg, #ccc 25%, transparent 25%),
 			linear-gradient(45deg, transparent 75%, #ccc 75%),
 			linear-gradient(-45deg, transparent 75%, #ccc 75%);
 		background-size: 8px 8px;
-		background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+		background-position:
+			0 0,
+			0 4px,
+			4px -4px,
+			-4px 0;
 	}
 
 	&__swatch-empty {
@@ -644,7 +748,7 @@ defineExpose({ focus, blur, open, close });
 		flex-shrink: 0;
 		border-radius: 50%;
 		overflow: hidden;
-		border: 1px solid var(--ep-color-border, rgba(0,0,0,0.1));
+		border: 1px solid var(--ep-color-border, rgba(0, 0, 0, 0.1));
 	}
 	&__preview {
 		width: 100%;
@@ -678,7 +782,10 @@ defineExpose({ focus, blur, open, close });
 	}
 
 	&__alpha {
-		background: var(--ep-color-picker-alpha-bg, linear-gradient(to right, transparent, #000));
+		background: var(
+			--ep-color-picker-alpha-bg,
+			linear-gradient(to right, transparent, #000)
+		);
 	}
 
 	&__hue::-webkit-slider-thumb,
@@ -782,15 +889,23 @@ defineExpose({ focus, blur, open, close });
 
 	&__alert {
 		font-size: 0.75rem;
-		&--error { color: var(--ep-color-error); }
-		&--warning { color: var(--ep-color-warning); }
-		&--success { color: var(--ep-color-success); }
+		&--error {
+			color: var(--ep-color-error);
+		}
+		&--warning {
+			color: var(--ep-color-warning);
+		}
+		&--success {
+			color: var(--ep-color-success);
+		}
 	}
 }
 
 .ep-color-picker-pop-enter-active,
 .ep-color-picker-pop-leave-active {
-	transition: opacity 0.12s ease, transform 0.12s ease;
+	transition:
+		opacity 0.12s ease,
+		transform 0.12s ease;
 }
 .ep-color-picker-pop-enter-from,
 .ep-color-picker-pop-leave-to {

--- a/packages/ecosphere/src/data-entry/InputField.story.vue
+++ b/packages/ecosphere/src/data-entry/InputField.story.vue
@@ -6,19 +6,43 @@ const value = ref("");
 <template>
 	<Story title="Data entry/Input">
 		<Variant title="Default">
-			<InputField v-model:value="value" label="Name" placeholder="Type here" />
+			<InputField
+				v-model:value="value"
+				label="Name"
+				placeholder="Type here"
+			/>
 		</Variant>
 		<Variant title="With prefix / suffix">
-			<InputField v-model:value="value" label="Amount" prefix="$" suffix="USD" />
+			<InputField
+				v-model:value="value"
+				label="Amount"
+				prefix="$"
+				suffix="USD"
+			/>
 		</Variant>
 		<Variant title="Addon before / after">
-			<InputField v-model:value="value" label="URL" addon-before="https://" addon-after=".com" />
+			<InputField
+				v-model:value="value"
+				label="URL"
+				addon-before="https://"
+				addon-after=".com"
+			/>
 		</Variant>
 		<Variant title="Clearable + show count">
-			<InputField v-model:value="value" label="Tag" allow-clear :max-length="20" show-count />
+			<InputField
+				v-model:value="value"
+				label="Tag"
+				allow-clear
+				:max-length="20"
+				show-count
+			/>
 		</Variant>
 		<Variant title="Password">
-			<InputField v-model:value="value" label="Password" type="password" />
+			<InputField
+				v-model:value="value"
+				label="Password"
+				type="password"
+			/>
 		</Variant>
 		<Variant title="Search">
 			<InputField v-model:value="value" label="Search" type="search" />

--- a/packages/ecosphere/src/data-entry/InputField.vue
+++ b/packages/ecosphere/src/data-entry/InputField.vue
@@ -21,11 +21,17 @@
 			{{ label }}
 		</label>
 		<div class="ep-input__row">
-			<div v-if="hasAddonBefore" class="ep-input__addon ep-input__addon--before">
+			<div
+				v-if="hasAddonBefore"
+				class="ep-input__addon ep-input__addon--before"
+			>
 				<slot name="addonBefore">{{ addonBefore }}</slot>
 			</div>
 			<div class="ep-input__wrapper">
-				<span v-if="hasPrefix" class="ep-input__affix ep-input__affix--prefix">
+				<span
+					v-if="hasPrefix"
+					class="ep-input__affix ep-input__affix--prefix"
+				>
 					<slot name="prefix">{{ prefix }}</slot>
 				</span>
 				<input
@@ -47,7 +53,10 @@
 					@focus="emit('focus', $event)"
 					@blur="emit('blur', $event)"
 				/>
-				<span v-if="hasSuffix" class="ep-input__affix ep-input__affix--suffix">
+				<span
+					v-if="hasSuffix"
+					class="ep-input__affix ep-input__affix--suffix"
+				>
 					<button
 						v-if="allowClear && hasValue && !disabled && !readonly"
 						type="button"
@@ -61,11 +70,18 @@
 						v-if="type === 'password'"
 						type="button"
 						class="ep-input__icon-btn"
-						:aria-label="showPassword ? 'Hide password' : 'Show password'"
+						:aria-label="
+							showPassword ? 'Hide password' : 'Show password'
+						"
 						:aria-pressed="showPassword ? 'true' : 'false'"
 						@click="showPassword = !showPassword"
 					>
-						<SVGIcon :name="showPassword ? 'ri-eye-off-line' : 'ri-eye-line'" aria-hidden />
+						<SVGIcon
+							:name="
+								showPassword ? 'ri-eye-off-line' : 'ri-eye-line'
+							"
+							aria-hidden
+						/>
 					</button>
 					<button
 						v-if="type === 'search'"
@@ -79,7 +95,10 @@
 					<slot name="suffix">{{ suffix }}</slot>
 				</span>
 			</div>
-			<div v-if="hasAddonAfter" class="ep-input__addon ep-input__addon--after">
+			<div
+				v-if="hasAddonAfter"
+				class="ep-input__addon ep-input__addon--after"
+			>
 				<slot name="addonAfter">{{ addonAfter }}</slot>
 			</div>
 		</div>
@@ -96,7 +115,10 @@
 				{{ assistiveText }}
 			</div>
 			<div v-if="showCount" class="ep-input__count">
-				{{ currentLength }}<template v-if="maxLength != null"> / {{ maxLength }}</template>
+				{{ currentLength
+				}}<template v-if="maxLength != null">
+					/ {{ maxLength }}</template
+				>
 			</div>
 		</div>
 	</div>
@@ -109,7 +131,13 @@ import { useEpId } from "../composables/useEpId";
 import { useEpSize } from "../composables/useEpSize";
 import type { EpSize } from "../general/config";
 
-export type InputType = "text" | "email" | "password" | "search" | "tel" | "url";
+export type InputType =
+	| "text"
+	| "email"
+	| "password"
+	| "search"
+	| "tel"
+	| "url";
 export type DataEntryState = "default" | "error" | "warning" | "success";
 export type InputValue = string | number | null;
 
@@ -184,15 +212,18 @@ const internalValue = computed<InputValue>({
 });
 
 const fieldType = computed<InputType>(() =>
-	props.type === "password" && showPassword.value ? "text" : props.type,
+	props.type === "password" && showPassword.value ? "text" : props.type
 );
 
 const hasValue = computed(
-	() => internalValue.value !== null && internalValue.value !== "" && internalValue.value !== undefined,
+	() =>
+		internalValue.value !== null &&
+		internalValue.value !== "" &&
+		internalValue.value !== undefined
 );
 
 const currentLength = computed(() =>
-	internalValue.value == null ? 0 : String(internalValue.value).length,
+	internalValue.value == null ? 0 : String(internalValue.value).length
 );
 
 const hasPrefix = computed(() => !!props.prefix || !!slots.prefix);
@@ -202,15 +233,17 @@ const hasSuffix = computed(
 		!!slots.suffix ||
 		props.allowClear ||
 		props.type === "password" ||
-		props.type === "search",
+		props.type === "search"
 );
-const hasAddonBefore = computed(() => !!props.addonBefore || !!slots.addonBefore);
+const hasAddonBefore = computed(
+	() => !!props.addonBefore || !!slots.addonBefore
+);
 const hasAddonAfter = computed(() => !!props.addonAfter || !!slots.addonAfter);
 const hasFooter = computed(
 	() =>
 		(props.alertMessage && props.state !== "default") ||
 		!!props.assistiveText ||
-		props.showCount,
+		props.showCount
 );
 
 function onInput(e: Event) {
@@ -231,7 +264,10 @@ function clearValue() {
 	inputRef.value?.focus();
 }
 
-defineExpose({ focus: () => inputRef.value?.focus(), blur: () => inputRef.value?.blur() });
+defineExpose({
+	focus: () => inputRef.value?.focus(),
+	blur: () => inputRef.value?.blur(),
+});
 </script>
 
 <style scoped>

--- a/packages/ecosphere/src/data-entry/InputNumberField.story.vue
+++ b/packages/ecosphere/src/data-entry/InputNumberField.story.vue
@@ -9,13 +9,28 @@ const n = ref<number | null>(5);
 			<InputNumberField v-model:value="n" label="Quantity" />
 		</Variant>
 		<Variant title="Min/Max + step">
-			<InputNumberField v-model:value="n" label="Volume" :min="0" :max="10" :step="2" />
+			<InputNumberField
+				v-model:value="n"
+				label="Volume"
+				:min="0"
+				:max="10"
+				:step="2"
+			/>
 		</Variant>
 		<Variant title="Precision (2dp)">
-			<InputNumberField v-model:value="n" label="Price" :step="0.1" :precision="2" />
+			<InputNumberField
+				v-model:value="n"
+				label="Price"
+				:step="0.1"
+				:precision="2"
+			/>
 		</Variant>
 		<Variant title="No controls">
-			<InputNumberField v-model:value="n" label="Pages" :controls="false" />
+			<InputNumberField
+				v-model:value="n"
+				label="Pages"
+				:controls="false"
+			/>
 		</Variant>
 	</Story>
 </template>

--- a/packages/ecosphere/src/data-entry/InputNumberField.vue
+++ b/packages/ecosphere/src/data-entry/InputNumberField.vue
@@ -45,7 +45,11 @@
 					@focus="emit('focus', $event)"
 					@blur="onBlur($event)"
 				/>
-				<div v-if="controls" class="ep-input-number__controls" aria-hidden="true">
+				<div
+					v-if="controls"
+					class="ep-input-number__controls"
+					aria-hidden="true"
+				>
 					<button
 						type="button"
 						class="ep-input-number__btn"
@@ -154,17 +158,29 @@ const displayValue = computed(() => {
 	return String(props.value);
 });
 
-const canIncrement = computed(() => props.max === null || (props.value ?? 0) + stepValue.value <= (props.max as number));
-const canDecrement = computed(() => props.min === null || (props.value ?? 0) - stepValue.value >= (props.min as number));
+const canIncrement = computed(
+	() =>
+		props.max === null ||
+		(props.value ?? 0) + stepValue.value <= (props.max as number)
+);
+const canDecrement = computed(
+	() =>
+		props.min === null ||
+		(props.value ?? 0) - stepValue.value >= (props.min as number)
+);
 
 const hasFooter = computed(
-	() => (props.alertMessage && props.state !== "default") || !!props.assistiveText,
+	() =>
+		(props.alertMessage && props.state !== "default") ||
+		!!props.assistiveText
 );
 
 function clamp(n: number): number {
 	let r = n;
-	if (props.min !== null && r < (props.min as number)) r = props.min as number;
-	if (props.max !== null && r > (props.max as number)) r = props.max as number;
+	if (props.min !== null && r < (props.min as number))
+		r = props.min as number;
+	if (props.max !== null && r > (props.max as number))
+		r = props.max as number;
 	if (props.precision !== null) r = Number(r.toFixed(props.precision));
 	return r;
 }
@@ -203,7 +219,10 @@ function step(delta: number) {
 	emit("update:value", next);
 }
 
-defineExpose({ focus: () => inputRef.value?.focus(), blur: () => inputRef.value?.blur() });
+defineExpose({
+	focus: () => inputRef.value?.focus(),
+	blur: () => inputRef.value?.blur(),
+});
 </script>
 
 <style scoped>

--- a/packages/ecosphere/src/data-entry/RadioField.story.vue
+++ b/packages/ecosphere/src/data-entry/RadioField.story.vue
@@ -6,8 +6,16 @@ const value = ref<string | number | boolean | null>("a");
 <template>
 	<Story title="Data entry/Radio">
 		<Variant title="Default">
-			<RadioField v-model:value="value" native-value="a" label="Option A" />
-			<RadioField v-model:value="value" native-value="b" label="Option B" />
+			<RadioField
+				v-model:value="value"
+				native-value="a"
+				label="Option A"
+			/>
+			<RadioField
+				v-model:value="value"
+				native-value="b"
+				label="Option B"
+			/>
 		</Variant>
 		<Variant title="Disabled">
 			<RadioField :value="'a'" native-value="b" disabled label="Locked" />

--- a/packages/ecosphere/src/data-entry/RadioField.vue
+++ b/packages/ecosphere/src/data-entry/RadioField.vue
@@ -25,7 +25,11 @@
 			@focus="emit('focus', $event)"
 			@blur="emit('blur', $event)"
 		/>
-		<span v-if="optionType === 'default'" class="ep-radio__circle" aria-hidden="true">
+		<span
+			v-if="optionType === 'default'"
+			class="ep-radio__circle"
+			aria-hidden="true"
+		>
 			<span class="ep-radio__dot" />
 		</span>
 		<span class="ep-radio__label">
@@ -195,7 +199,10 @@ function onChange(e: Event) {
 		color: var(--ep-color-secondary);
 	}
 	&--checked.ep-radio--secondary-variant &__circle {
-		border-color: var(--ep-color-secondary-variant, var(--ep-color-secondary));
+		border-color: var(
+			--ep-color-secondary-variant,
+			var(--ep-color-secondary)
+		);
 		color: var(--ep-color-secondary-variant, var(--ep-color-secondary));
 	}
 	&--checked.ep-radio--information &__circle {

--- a/packages/ecosphere/src/data-entry/RadioGroup.vue
+++ b/packages/ecosphere/src/data-entry/RadioGroup.vue
@@ -45,10 +45,7 @@
 		>
 			{{ alertMessage }}
 		</div>
-		<div
-			v-else-if="assistiveText"
-			class="ep-radio-group__assistive-text"
-		>
+		<div v-else-if="assistiveText" class="ep-radio-group__assistive-text">
 			{{ assistiveText }}
 		</div>
 	</div>
@@ -61,7 +58,11 @@ import { useEpId } from "../composables/useEpId";
 import { useEpSize } from "../composables/useEpSize";
 import type { EpSize } from "../general/config";
 import type { EpHue } from "../utilities/types/shared";
-import type { RadioValue, RadioOptionType, RadioButtonStyle } from "./RadioField.vue";
+import type {
+	RadioValue,
+	RadioOptionType,
+	RadioButtonStyle,
+} from "./RadioField.vue";
 
 export interface RadioOption {
 	label: string;
@@ -120,12 +121,16 @@ const groupName = computed(() => props.name ?? autoName);
 
 const normalizedOptions = computed<RadioOption[]>(() =>
 	props.options
-		.map((opt): RadioOption =>
-			typeof opt === "object" && opt !== null && "label" in opt
-				? (opt as RadioOption)
-				: { label: String(opt), value: opt as string | number | boolean },
+		.map(
+			(opt): RadioOption =>
+				typeof opt === "object" && opt !== null && "label" in opt
+					? (opt as RadioOption)
+					: {
+							label: String(opt),
+							value: opt as string | number | boolean,
+						}
 		)
-		.filter((opt) => !opt.hidden),
+		.filter((opt) => !opt.hidden)
 );
 
 function handleUpdate(v: RadioValue) {

--- a/packages/ecosphere/src/data-entry/SelectField.story.vue
+++ b/packages/ecosphere/src/data-entry/SelectField.story.vue
@@ -12,22 +12,53 @@ const big = Array.from({ length: 500 }, (_, i) => `Option ${i + 1}`);
 <template>
 	<Story title="Data entry/Select">
 		<Variant title="Single">
-			<SelectField v-model:value="single" label="Fruit" :options="options" />
+			<SelectField
+				v-model:value="single"
+				label="Fruit"
+				:options="options"
+			/>
 		</Variant>
 		<Variant title="Multiple">
-			<SelectField v-model:value="multi" label="Fruits" :options="options" multiple allow-clear />
+			<SelectField
+				v-model:value="multi"
+				label="Fruits"
+				:options="options"
+				multiple
+				allow-clear
+			/>
 		</Variant>
 		<Variant title="Searchable">
-			<SelectField v-model:value="single" label="Fruit" :options="options" show-search />
+			<SelectField
+				v-model:value="single"
+				label="Fruit"
+				:options="options"
+				show-search
+			/>
 		</Variant>
 		<Variant title="Tags">
-			<SelectField v-model:value="tagged" label="Tags" :options="options" tags allow-clear />
+			<SelectField
+				v-model:value="tagged"
+				label="Tags"
+				:options="options"
+				tags
+				allow-clear
+			/>
 		</Variant>
 		<Variant title="Virtual scroll (500 opts)">
-			<SelectField v-model:value="single" label="Pick one" :options="big" show-search />
+			<SelectField
+				v-model:value="single"
+				label="Pick one"
+				:options="big"
+				show-search
+			/>
 		</Variant>
 		<Variant title="Loading">
-			<SelectField v-model:value="single" label="Async" :options="[]" loading />
+			<SelectField
+				v-model:value="single"
+				label="Async"
+				:options="[]"
+				loading
+			/>
 		</Variant>
 	</Story>
 </template>

--- a/packages/ecosphere/src/data-entry/SelectField.vue
+++ b/packages/ecosphere/src/data-entry/SelectField.vue
@@ -64,7 +64,9 @@
 						</span>
 					</template>
 					<template v-else-if="selectedSingle">
-						<span class="ep-select__single">{{ selectedSingle.label }}</span>
+						<span class="ep-select__single">{{
+							selectedSingle.label
+						}}</span>
 					</template>
 
 					<input
@@ -84,7 +86,8 @@
 					<span
 						v-else-if="!hasSelection"
 						class="ep-select__placeholder"
-					>{{ placeholder }}</span>
+						>{{ placeholder }}</span
+					>
 				</div>
 				<div class="ep-select__icons">
 					<button
@@ -107,7 +110,11 @@
 					<SVGIcon
 						v-else
 						class="ep-select__icon"
-						:name="isOpen ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line'"
+						:name="
+							isOpen
+								? 'ri-arrow-up-s-line'
+								: 'ri-arrow-down-s-line'
+						"
 						aria-hidden
 					/>
 				</div>
@@ -119,19 +126,24 @@
 					ref="listboxRef"
 					class="ep-select__listbox"
 					role="listbox"
-					:aria-multiselectable="isMultiple || tags ? 'true' : undefined"
+					:aria-multiselectable="
+						isMultiple || tags ? 'true' : undefined
+					"
 					:style="{ maxHeight: `${listboxMaxHeight}px` }"
 					@mousedown.prevent
 					@scroll="onListScroll"
 				>
+					<div v-if="loading" class="ep-select__loading">
+						{{ loadingText }}
+					</div>
 					<div
-						v-if="loading"
-						class="ep-select__loading"
-					>{{ loadingText }}</div>
-					<div
-						v-else-if="filteredOptions.length === 0 && !canCreateTag"
+						v-else-if="
+							filteredOptions.length === 0 && !canCreateTag
+						"
 						class="ep-select__empty"
-					>{{ notFoundText }}</div>
+					>
+						{{ notFoundText }}
+					</div>
 					<div
 						v-else
 						class="ep-select__virtual"
@@ -139,12 +151,14 @@
 					>
 						<div
 							class="ep-select__virtual-window"
-							:style="{ transform: `translateY(${virtualOffsetY}px)` }"
+							:style="{
+								transform: `translateY(${virtualOffsetY}px)`,
+							}"
 						>
 							<div
 								v-for="(opt, vi) in visibleOptions"
-								:key="`${opt.value}-${virtualStart + vi}`"
 								:id="`${listboxId}-opt-${virtualStart + vi}`"
+								:key="`${opt.value}-${virtualStart + vi}`"
 								class="ep-select__option"
 								:class="[
 									{
@@ -152,17 +166,22 @@
 											virtualStart + vi === activeIndex,
 										'ep-select__option--selected':
 											isSelected(opt.value),
-										'ep-select__option--disabled': opt.disabled,
+										'ep-select__option--disabled':
+											opt.disabled,
 									},
 								]"
 								role="option"
-								:aria-selected="isSelected(opt.value) ? 'true' : 'false'"
+								:aria-selected="
+									isSelected(opt.value) ? 'true' : 'false'
+								"
 								:aria-disabled="opt.disabled || undefined"
 								:style="{ height: `${optionHeight}px` }"
 								@click="selectOption(opt)"
 								@mouseenter="activeIndex = virtualStart + vi"
 							>
-								<span class="ep-select__option-label">{{ opt.label }}</span>
+								<span class="ep-select__option-label">{{
+									opt.label
+								}}</span>
 								<SVGIcon
 									v-if="isSelected(opt.value)"
 									class="ep-select__option-check"
@@ -191,7 +210,9 @@
 				class="ep-select__alert"
 				:class="`ep-select__alert--${state}`"
 				role="alert"
-			>{{ alertMessage }}</div>
+			>
+				{{ alertMessage }}
+			</div>
 			<div v-else-if="assistiveText" class="ep-select__assistive">
 				{{ assistiveText }}
 			</div>
@@ -200,7 +221,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import {
+	computed,
+	nextTick,
+	onBeforeUnmount,
+	onMounted,
+	ref,
+	watch,
+} from "vue";
 import SVGIcon from "../general/SVGIcon.vue";
 import { useEpId } from "../composables/useEpId";
 import { useEpSize } from "../composables/useEpSize";
@@ -311,14 +339,17 @@ function normalizeOption(o: SelectOptionLike): SelectOption {
 }
 
 const allOptions = computed<SelectOption[]>(() => {
-	const base = (props.options || []).map(normalizeOption).filter((o) => !o.hidden);
+	const base = (props.options || [])
+		.map(normalizeOption)
+		.filter((o) => !o.hidden);
 	return [...base, ...dynamicOptions.value];
 });
 
 const filteredOptions = computed<SelectOption[]>(() => {
 	const q = searchText.value.trim().toLowerCase();
 	if (!q || (!props.showSearch && !props.tags)) return allOptions.value;
-	if (props.filter) return allOptions.value.filter((o) => props.filter!(o, q));
+	if (props.filter)
+		return allOptions.value.filter((o) => props.filter!(o, q));
 	return allOptions.value.filter((o) => o.label.toLowerCase().includes(q));
 });
 
@@ -326,12 +357,16 @@ const canCreateTag = computed(() => {
 	if (!props.tags) return false;
 	const q = searchText.value.trim();
 	if (!q) return false;
-	return !allOptions.value.some((o) => String(o.value).toLowerCase() === q.toLowerCase());
+	return !allOptions.value.some(
+		(o) => String(o.value).toLowerCase() === q.toLowerCase()
+	);
 });
 
 const valuesArray = computed<SelectPrimitive[]>(() => {
 	if (props.value == null) return [];
-	return Array.isArray(props.value) ? props.value : [props.value as SelectPrimitive];
+	return Array.isArray(props.value)
+		? props.value
+		: [props.value as SelectPrimitive];
 });
 
 function isSelected(v: SelectPrimitive): boolean {
@@ -348,32 +383,45 @@ const selectedSingle = computed<SelectOption | null>(() => {
 const selectedDisplay = computed<SelectOption[]>(() => {
 	if (!isMultiple.value) return [];
 	return valuesArray.value.map(
-		(v) => allOptions.value.find((o) => o.value === v) ?? { label: String(v), value: v },
+		(v) =>
+			allOptions.value.find((o) => o.value === v) ?? {
+				label: String(v),
+				value: v,
+			}
 	);
 });
 
-const hasSelection = computed(
-	() => (isMultiple.value ? valuesArray.value.length > 0 : selectedSingle.value !== null),
+const hasSelection = computed(() =>
+	isMultiple.value
+		? valuesArray.value.length > 0
+		: selectedSingle.value !== null
 );
 
 const hasFooter = computed(
-	() => (!!props.assistiveText || (!!props.alertMessage && props.state !== "default")),
+	() =>
+		!!props.assistiveText ||
+		(!!props.alertMessage && props.state !== "default")
 );
 
 // Virtual scroll
 const scrollTop = ref(0);
-const visibleCount = computed(() => Math.ceil(props.listMaxHeight / props.optionHeight) + 4);
+const visibleCount = computed(
+	() => Math.ceil(props.listMaxHeight / props.optionHeight) + 4
+);
 const virtualStart = computed(() =>
-	Math.max(0, Math.floor(scrollTop.value / props.optionHeight) - 2),
+	Math.max(0, Math.floor(scrollTop.value / props.optionHeight) - 2)
 );
 const virtualEnd = computed(() =>
-	Math.min(filteredOptions.value.length, virtualStart.value + visibleCount.value),
+	Math.min(
+		filteredOptions.value.length,
+		virtualStart.value + visibleCount.value
+	)
 );
 const visibleOptions = computed(() =>
-	filteredOptions.value.slice(virtualStart.value, virtualEnd.value),
+	filteredOptions.value.slice(virtualStart.value, virtualEnd.value)
 );
 const virtualTotalHeight = computed(
-	() => filteredOptions.value.length * props.optionHeight,
+	() => filteredOptions.value.length * props.optionHeight
 );
 const virtualOffsetY = computed(() => virtualStart.value * props.optionHeight);
 
@@ -537,7 +585,11 @@ function onSearchKeydown(e: KeyboardEvent) {
 			triggerRef.value?.focus();
 			break;
 		case "Backspace":
-			if (!searchText.value && isMultiple.value && valuesArray.value.length) {
+			if (
+				!searchText.value &&
+				isMultiple.value &&
+				valuesArray.value.length
+			) {
 				removeValue(valuesArray.value[valuesArray.value.length - 1]);
 			}
 			break;
@@ -613,8 +665,11 @@ onBeforeUnmount(() => document.removeEventListener("mousedown", onDocClick));
 watch(
 	() => props.options,
 	() => {
-		activeIndex.value = Math.min(activeIndex.value, filteredOptions.value.length - 1);
-	},
+		activeIndex.value = Math.min(
+			activeIndex.value,
+			filteredOptions.value.length - 1
+		);
+	}
 );
 
 function focus() {
@@ -640,9 +695,15 @@ defineExpose({ focus, blur, open, close });
 		font-weight: 500;
 		color: var(--ep-color-text, currentColor);
 
-		&--error { color: var(--ep-color-error); }
-		&--warning { color: var(--ep-color-warning); }
-		&--success { color: var(--ep-color-success); }
+		&--error {
+			color: var(--ep-color-error);
+		}
+		&--warning {
+			color: var(--ep-color-warning);
+		}
+		&--success {
+			color: var(--ep-color-success);
+		}
 	}
 
 	&__wrapper {
@@ -684,11 +745,26 @@ defineExpose({ focus, blur, open, close });
 		opacity: 0.6;
 	}
 
-	&--xs &__trigger { font-size: 0.75rem; padding: 0.125rem 0.375rem; }
-	&--sm &__trigger { font-size: 0.8125rem; padding: 0.1875rem 0.5rem; }
-	&--md &__trigger { font-size: 0.9375rem; padding: 0.25rem 0.625rem; }
-	&--lg &__trigger { font-size: 1rem; padding: 0.375rem 0.75rem; }
-	&--xl &__trigger { font-size: 1.125rem; padding: 0.5rem 0.875rem; }
+	&--xs &__trigger {
+		font-size: 0.75rem;
+		padding: 0.125rem 0.375rem;
+	}
+	&--sm &__trigger {
+		font-size: 0.8125rem;
+		padding: 0.1875rem 0.5rem;
+	}
+	&--md &__trigger {
+		font-size: 0.9375rem;
+		padding: 0.25rem 0.625rem;
+	}
+	&--lg &__trigger {
+		font-size: 1rem;
+		padding: 0.375rem 0.75rem;
+	}
+	&--xl &__trigger {
+		font-size: 1.125rem;
+		padding: 0.5rem 0.875rem;
+	}
 
 	&__selection {
 		flex: 1;
@@ -715,7 +791,10 @@ defineExpose({ focus, blur, open, close });
 		align-items: center;
 		column-gap: 0.25rem;
 		padding: 0 0.375rem;
-		background: var(--ep-color-primary-tint, var(--ep-color-surface-alt, #eef));
+		background: var(
+			--ep-color-primary-tint,
+			var(--ep-color-surface-alt, #eef)
+		);
 		color: var(--ep-color-text);
 		border-radius: var(--ep-radius-sm, 4px);
 		font-size: 0.8125em;
@@ -729,7 +808,9 @@ defineExpose({ focus, blur, open, close });
 		font-size: 0.875em;
 		color: var(--ep-color-disabled, currentColor);
 
-		&:hover { color: var(--ep-color-text); }
+		&:hover {
+			color: var(--ep-color-text);
+		}
 	}
 
 	&__search {
@@ -761,7 +842,9 @@ defineExpose({ focus, blur, open, close });
 		padding: 0.125rem;
 		border-radius: 4px;
 
-		&:hover { color: var(--ep-color-text); }
+		&:hover {
+			color: var(--ep-color-text);
+		}
 	}
 
 	&__icon {
@@ -857,15 +940,23 @@ defineExpose({ focus, blur, open, close });
 	}
 
 	&__alert {
-		&--error { color: var(--ep-color-error); }
-		&--warning { color: var(--ep-color-warning); }
-		&--success { color: var(--ep-color-success); }
+		&--error {
+			color: var(--ep-color-error);
+		}
+		&--warning {
+			color: var(--ep-color-warning);
+		}
+		&--success {
+			color: var(--ep-color-success);
+		}
 	}
 }
 
 .ep-select-pop-enter-active,
 .ep-select-pop-leave-active {
-	transition: opacity 0.12s ease, transform 0.12s ease;
+	transition:
+		opacity 0.12s ease,
+		transform 0.12s ease;
 }
 .ep-select-pop-enter-from,
 .ep-select-pop-leave-to {
@@ -874,6 +965,8 @@ defineExpose({ focus, blur, open, close });
 }
 
 @keyframes ep-select-spin {
-	to { transform: rotate(360deg); }
+	to {
+		transform: rotate(360deg);
+	}
 }
 </style>

--- a/packages/ecosphere/src/data-entry/SwitchComponent.story.vue
+++ b/packages/ecosphere/src/data-entry/SwitchComponent.story.vue
@@ -12,7 +12,11 @@ const value = ref(false);
 			<SwitchComponent :value="true" label="Saving" loading />
 		</Variant>
 		<Variant title="With slots">
-			<SwitchComponent v-model:value="value" checked-text="ON" unchecked-text="OFF" />
+			<SwitchComponent
+				v-model:value="value"
+				checked-text="ON"
+				unchecked-text="OFF"
+			/>
 		</Variant>
 	</Story>
 </template>

--- a/packages/ecosphere/src/data-entry/SwitchComponent.vue
+++ b/packages/ecosphere/src/data-entry/SwitchComponent.vue
@@ -24,7 +24,11 @@
 			@keydown.space.prevent="toggle"
 		>
 			<span class="ep-switch__thumb">
-				<span v-if="loading" class="ep-switch__spinner" aria-hidden="true">
+				<span
+					v-if="loading"
+					class="ep-switch__spinner"
+					aria-hidden="true"
+				>
 					<svg
 						viewBox="0 0 24 24"
 						width="0.75em"

--- a/packages/ecosphere/src/data-entry/TextareaField.story.vue
+++ b/packages/ecosphere/src/data-entry/TextareaField.story.vue
@@ -6,13 +6,26 @@ const value = ref("");
 <template>
 	<Story title="Data entry/Textarea">
 		<Variant title="Default">
-			<TextareaField v-model:value="value" label="Notes" placeholder="Type" />
+			<TextareaField
+				v-model:value="value"
+				label="Notes"
+				placeholder="Type"
+			/>
 		</Variant>
 		<Variant title="AutoSize">
-			<TextareaField v-model:value="value" label="Bio" :auto-size="{ minRows: 2, maxRows: 6 }" />
+			<TextareaField
+				v-model:value="value"
+				label="Bio"
+				:auto-size="{ minRows: 2, maxRows: 6 }"
+			/>
 		</Variant>
 		<Variant title="Show count">
-			<TextareaField v-model:value="value" label="Comment" :max-length="120" show-count />
+			<TextareaField
+				v-model:value="value"
+				label="Comment"
+				:max-length="120"
+				show-count
+			/>
 		</Variant>
 		<Variant title="Clearable">
 			<TextareaField v-model:value="value" label="Notes" allow-clear />

--- a/packages/ecosphere/src/data-entry/TextareaField.vue
+++ b/packages/ecosphere/src/data-entry/TextareaField.vue
@@ -60,7 +60,10 @@
 				{{ assistiveText }}
 			</div>
 			<div v-if="showCount" class="ep-input__count">
-				{{ currentLength }}<template v-if="maxLength != null"> / {{ maxLength }}</template>
+				{{ currentLength
+				}}<template v-if="maxLength != null">
+					/ {{ maxLength }}</template
+				>
 			</div>
 		</div>
 	</div>
@@ -133,10 +136,13 @@ const internalValue = computed<TextareaValue>({
 	set: (v) => emit("update:value", v),
 });
 
-const hasValue = computed(() => internalValue.value !== null && internalValue.value !== "");
+const hasValue = computed(
+	() => internalValue.value !== null && internalValue.value !== ""
+);
 const currentLength = computed(() => (internalValue.value ?? "").length);
 const effectiveRows = computed(() => {
-	if (typeof props.autoSize === "object" && props.autoSize.minRows) return props.autoSize.minRows;
+	if (typeof props.autoSize === "object" && props.autoSize.minRows)
+		return props.autoSize.minRows;
 	return props.rows;
 });
 
@@ -144,7 +150,7 @@ const hasFooter = computed(
 	() =>
 		(props.alertMessage && props.state !== "default") ||
 		!!props.assistiveText ||
-		props.showCount,
+		props.showCount
 );
 
 function resize() {
@@ -173,9 +179,18 @@ function clearValue() {
 	textareaRef.value?.focus();
 }
 
-watch(() => internalValue.value, () => { if (props.autoSize) nextTick(resize); }, { immediate: true });
+watch(
+	() => internalValue.value,
+	() => {
+		if (props.autoSize) nextTick(resize);
+	},
+	{ immediate: true }
+);
 
-defineExpose({ focus: () => textareaRef.value?.focus(), blur: () => textareaRef.value?.blur() });
+defineExpose({
+	focus: () => textareaRef.value?.focus(),
+	blur: () => textareaRef.value?.blur(),
+});
 </script>
 
 <style scoped>

--- a/packages/ecosphere/src/data-entry/__tests__/CheckboxField.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/CheckboxField.spec.ts
@@ -5,7 +5,9 @@ import { expectNoA11yViolations } from "../../test/a11y";
 
 describe("EpCheckbox", () => {
 	it("renders an accessible native checkbox", () => {
-		const w = mount(CheckboxField, { props: { label: "Agree", value: false } });
+		const w = mount(CheckboxField, {
+			props: { label: "Agree", value: false },
+		});
 		const input = w.find("input[type=checkbox]");
 		expect(input.exists()).toBe(true);
 		expect(input.attributes("aria-checked")).toBe("false");
@@ -30,7 +32,9 @@ describe("EpCheckbox", () => {
 		});
 		expect(w.classes()).toContain("ep-checkbox--indeterminate");
 		expect(w.find("input").attributes("aria-checked")).toBe("mixed");
-		expect((w.find("input").element as HTMLInputElement).indeterminate).toBe(true);
+		expect(
+			(w.find("input").element as HTMLInputElement).indeterminate
+		).toBe(true);
 	});
 
 	it("does not toggle when disabled", async () => {

--- a/packages/ecosphere/src/data-entry/__tests__/ChoiceChips.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/ChoiceChips.spec.ts
@@ -11,7 +11,9 @@ const opts = [
 
 describe("EpChoiceChips", () => {
 	it("renders chips as buttons with aria-pressed", () => {
-		const w = mount(ChoiceChips, { props: { label: "Size", options: opts, value: "md" } });
+		const w = mount(ChoiceChips, {
+			props: { label: "Size", options: opts, value: "md" },
+		});
 		const chips = w.findAll(".ep-choice-chips__chip");
 		expect(chips.length).toBe(3);
 		expect(chips[0].attributes("aria-pressed")).toBe("false");
@@ -19,13 +21,17 @@ describe("EpChoiceChips", () => {
 	});
 
 	it("selects single value on click", async () => {
-		const w = mount(ChoiceChips, { props: { label: "x", options: opts, value: null } });
+		const w = mount(ChoiceChips, {
+			props: { label: "x", options: opts, value: null },
+		});
 		await w.findAll(".ep-choice-chips__chip")[0].trigger("click");
 		expect(w.emitted("update:value")?.[0]).toEqual(["sm"]);
 	});
 
 	it("toggles off single value when clicked again", async () => {
-		const w = mount(ChoiceChips, { props: { label: "x", options: opts, value: "sm" } });
+		const w = mount(ChoiceChips, {
+			props: { label: "x", options: opts, value: "sm" },
+		});
 		await w.findAll(".ep-choice-chips__chip")[0].trigger("click");
 		expect(w.emitted("update:value")?.[0]).toEqual([null]);
 	});
@@ -39,13 +45,17 @@ describe("EpChoiceChips", () => {
 	});
 
 	it("does not toggle disabled chips", async () => {
-		const w = mount(ChoiceChips, { props: { label: "x", options: opts, value: null } });
+		const w = mount(ChoiceChips, {
+			props: { label: "x", options: opts, value: null },
+		});
 		await w.findAll(".ep-choice-chips__chip")[2].trigger("click");
 		expect(w.emitted("update:value")).toBeFalsy();
 	});
 
 	it("normalizes string options", () => {
-		const w = mount(ChoiceChips, { props: { label: "x", options: ["a", "b"], value: null } });
+		const w = mount(ChoiceChips, {
+			props: { label: "x", options: ["a", "b"], value: null },
+		});
 		expect(w.findAll(".ep-choice-chips__chip").length).toBe(2);
 	});
 

--- a/packages/ecosphere/src/data-entry/__tests__/ColorPicker.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/ColorPicker.spec.ts
@@ -5,11 +5,15 @@ import { expectNoA11yViolations } from "../../test/a11y";
 
 describe("EpColorPicker", () => {
 	it("renders trigger with current swatch and aria-haspopup", () => {
-		const w = mount(ColorPicker, { props: { label: "Brand", value: "#ff0000" } });
+		const w = mount(ColorPicker, {
+			props: { label: "Brand", value: "#ff0000" },
+		});
 		const trig = w.find(".ep-color-picker__trigger");
 		expect(trig.attributes("aria-haspopup")).toBe("dialog");
 		expect(trig.attributes("aria-expanded")).toBe("false");
-		expect(w.find(".ep-color-picker__swatch").attributes("style")).toContain("background-color");
+		expect(
+			w.find(".ep-color-picker__swatch").attributes("style")
+		).toContain("background-color");
 	});
 
 	it("opens popover on trigger click", async () => {
@@ -19,7 +23,9 @@ describe("EpColorPicker", () => {
 		});
 		await w.find(".ep-color-picker__trigger").trigger("click");
 		expect(w.find('[role="dialog"]').exists()).toBe(true);
-		expect(w.find(".ep-color-picker__trigger").attributes("aria-expanded")).toBe("true");
+		expect(
+			w.find(".ep-color-picker__trigger").attributes("aria-expanded")
+		).toBe("true");
 		w.unmount();
 	});
 

--- a/packages/ecosphere/src/data-entry/__tests__/InputField.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/InputField.spec.ts
@@ -20,14 +20,21 @@ describe("EpInput", () => {
 	});
 
 	it("renders prefix and suffix", () => {
-		const w = mount(InputField, { props: { label: "x", value: "", prefix: "$", suffix: "USD" } });
+		const w = mount(InputField, {
+			props: { label: "x", value: "", prefix: "$", suffix: "USD" },
+		});
 		expect(w.find(".ep-input__affix--prefix").text()).toBe("$");
 		expect(w.find(".ep-input__affix--suffix").text()).toBe("USD");
 	});
 
 	it("renders addonBefore and addonAfter", () => {
 		const w = mount(InputField, {
-			props: { label: "x", value: "", addonBefore: "https://", addonAfter: ".com" },
+			props: {
+				label: "x",
+				value: "",
+				addonBefore: "https://",
+				addonAfter: ".com",
+			},
 		});
 		expect(w.find(".ep-input__addon--before").text()).toBe("https://");
 		expect(w.find(".ep-input__addon--after").text()).toBe(".com");
@@ -69,7 +76,12 @@ describe("EpInput", () => {
 
 	it("sets aria-invalid in error state", () => {
 		const w = mount(InputField, {
-			props: { label: "x", value: "", state: "error", alertMessage: "bad" },
+			props: {
+				label: "x",
+				value: "",
+				state: "error",
+				alertMessage: "bad",
+			},
 		});
 		expect(w.find("input").attributes("aria-invalid")).toBe("true");
 		expect(w.find(".ep-input__alert--error").text()).toBe("bad");
@@ -77,7 +89,11 @@ describe("EpInput", () => {
 
 	it("has no axe violations", async () => {
 		const w = mount(InputField, {
-			props: { label: "Name", value: "hi", assistiveText: "Enter your full name" },
+			props: {
+				label: "Name",
+				value: "hi",
+				assistiveText: "Enter your full name",
+			},
 			attachTo: document.body,
 		});
 		await expectNoA11yViolations(w.element as HTMLElement);

--- a/packages/ecosphere/src/data-entry/__tests__/InputNumberField.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/InputNumberField.spec.ts
@@ -5,32 +5,42 @@ import { expectNoA11yViolations } from "../../test/a11y";
 
 describe("EpInputNumber", () => {
 	it("renders spinbutton with aria-valuenow", () => {
-		const w = mount(InputNumberField, { props: { label: "Qty", value: 5 } });
+		const w = mount(InputNumberField, {
+			props: { label: "Qty", value: 5 },
+		});
 		const input = w.find("input");
 		expect(input.attributes("role")).toBe("spinbutton");
 		expect(input.attributes("aria-valuenow")).toBe("5");
 	});
 
 	it("increments via Up key", async () => {
-		const w = mount(InputNumberField, { props: { label: "x", value: 3, step: 2 } });
+		const w = mount(InputNumberField, {
+			props: { label: "x", value: 3, step: 2 },
+		});
 		await w.find("input").trigger("keydown.up");
 		expect(w.emitted("update:value")?.[0]).toEqual([5]);
 	});
 
 	it("decrements via Down key", async () => {
-		const w = mount(InputNumberField, { props: { label: "x", value: 3, step: 1 } });
+		const w = mount(InputNumberField, {
+			props: { label: "x", value: 3, step: 1 },
+		});
 		await w.find("input").trigger("keydown.down");
 		expect(w.emitted("update:value")?.[0]).toEqual([2]);
 	});
 
 	it("clamps to min", async () => {
-		const w = mount(InputNumberField, { props: { label: "x", value: 0, min: 0, step: 5 } });
+		const w = mount(InputNumberField, {
+			props: { label: "x", value: 0, min: 0, step: 5 },
+		});
 		await w.find("input").trigger("keydown.down");
 		expect(w.emitted("update:value")?.[0]).toEqual([0]);
 	});
 
 	it("clamps to max", async () => {
-		const w = mount(InputNumberField, { props: { label: "x", value: 10, max: 10, step: 5 } });
+		const w = mount(InputNumberField, {
+			props: { label: "x", value: 10, max: 10, step: 5 },
+		});
 		await w.find("input").trigger("keydown.up");
 		expect(w.emitted("update:value")?.[0]).toEqual([10]);
 	});
@@ -49,7 +59,9 @@ describe("EpInputNumber", () => {
 	});
 
 	it("hides controls when controls=false", () => {
-		const w = mount(InputNumberField, { props: { label: "x", value: 1, controls: false } });
+		const w = mount(InputNumberField, {
+			props: { label: "x", value: 1, controls: false },
+		});
 		expect(w.find(".ep-input-number__controls").exists()).toBe(false);
 	});
 

--- a/packages/ecosphere/src/data-entry/__tests__/RadioField.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/RadioField.spec.ts
@@ -32,7 +32,12 @@ describe("EpRadio", () => {
 
 	it("does not emit when disabled", async () => {
 		const w = mount(RadioField, {
-			props: { label: "A", nativeValue: "a", value: null, disabled: true },
+			props: {
+				label: "A",
+				nativeValue: "a",
+				value: null,
+				disabled: true,
+			},
 		});
 		await w.find("input").trigger("change");
 		expect(w.emitted("update:value")).toBeUndefined();
@@ -40,7 +45,12 @@ describe("EpRadio", () => {
 
 	it("renders button option type", () => {
 		const w = mount(RadioField, {
-			props: { label: "Day", nativeValue: "d", value: "d", optionType: "button" },
+			props: {
+				label: "Day",
+				nativeValue: "d",
+				value: "d",
+				optionType: "button",
+			},
 		});
 		expect(w.classes()).toContain("ep-radio--button");
 		expect(w.find(".ep-radio__circle").exists()).toBe(false);
@@ -55,7 +65,12 @@ describe("EpRadio", () => {
 
 	it("has no axe violations", async () => {
 		const w = mount(RadioField, {
-			props: { label: "Option A", nativeValue: "a", value: "a", name: "g1" },
+			props: {
+				label: "Option A",
+				nativeValue: "a",
+				value: "a",
+				name: "g1",
+			},
 			attachTo: document.body,
 		});
 		await expectNoA11yViolations(w.element as HTMLElement);

--- a/packages/ecosphere/src/data-entry/__tests__/SelectField.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/SelectField.spec.ts
@@ -11,7 +11,9 @@ const opts = [
 
 describe("EpSelect", () => {
 	it("renders combobox with aria attributes", () => {
-		const w = mount(SelectField, { props: { label: "Fruit", options: opts, value: null } });
+		const w = mount(SelectField, {
+			props: { label: "Fruit", options: opts, value: null },
+		});
 		const trig = w.find('[role="combobox"]');
 		expect(trig.exists()).toBe(true);
 		expect(trig.attributes("aria-expanded")).toBe("false");
@@ -93,7 +95,12 @@ describe("EpSelect", () => {
 
 	it("clears all on clear button", async () => {
 		const w = mount(SelectField, {
-			props: { label: "x", options: opts, value: "apple", allowClear: true },
+			props: {
+				label: "x",
+				options: opts,
+				value: "apple",
+				allowClear: true,
+			},
 		});
 		await w.find(".ep-select__icon-btn").trigger("click");
 		expect(w.emitted("update:value")?.[0]).toEqual([null]);
@@ -116,9 +123,17 @@ describe("EpSelect", () => {
 
 	it("sets aria-invalid in error state", () => {
 		const w = mount(SelectField, {
-			props: { label: "x", options: opts, value: null, state: "error", alertMessage: "bad" },
+			props: {
+				label: "x",
+				options: opts,
+				value: null,
+				state: "error",
+				alertMessage: "bad",
+			},
 		});
-		expect(w.find('[role="combobox"]').attributes("aria-invalid")).toBe("true");
+		expect(w.find('[role="combobox"]').attributes("aria-invalid")).toBe(
+			"true"
+		);
 	});
 
 	it("has no axe violations", async () => {

--- a/packages/ecosphere/src/data-entry/__tests__/SwitchComponent.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/SwitchComponent.spec.ts
@@ -35,7 +35,9 @@ describe("EpSwitch", () => {
 			props: { label: "x", value: true },
 		});
 		expect(w.classes()).toContain("ep-switch--checked");
-		expect(w.find('[role="switch"]').attributes("aria-checked")).toBe("true");
+		expect(w.find('[role="switch"]').attributes("aria-checked")).toBe(
+			"true"
+		);
 	});
 
 	it("does not toggle when disabled", async () => {

--- a/packages/ecosphere/src/data-entry/__tests__/TextareaField.spec.ts
+++ b/packages/ecosphere/src/data-entry/__tests__/TextareaField.spec.ts
@@ -5,7 +5,9 @@ import { expectNoA11yViolations } from "../../test/a11y";
 
 describe("EpTextarea", () => {
 	it("renders textarea with label association", () => {
-		const w = mount(TextareaField, { props: { label: "Notes", value: "" } });
+		const w = mount(TextareaField, {
+			props: { label: "Notes", value: "" },
+		});
 		const ta = w.find("textarea");
 		const label = w.find("label");
 		expect(ta.exists()).toBe(true);
@@ -21,7 +23,9 @@ describe("EpTextarea", () => {
 	});
 
 	it("respects rows prop", () => {
-		const w = mount(TextareaField, { props: { label: "x", value: "", rows: 6 } });
+		const w = mount(TextareaField, {
+			props: { label: "x", value: "", rows: 6 },
+		});
 		expect(w.find("textarea").attributes("rows")).toBe("6");
 	});
 
@@ -34,7 +38,12 @@ describe("EpTextarea", () => {
 
 	it("shows char count", () => {
 		const w = mount(TextareaField, {
-			props: { label: "x", value: "hello", showCount: true, maxLength: 20 },
+			props: {
+				label: "x",
+				value: "hello",
+				showCount: true,
+				maxLength: 20,
+			},
 		});
 		expect(w.find(".ep-input__count").text()).toBe("5 / 20");
 	});
@@ -50,7 +59,12 @@ describe("EpTextarea", () => {
 
 	it("sets aria-invalid in error state", () => {
 		const w = mount(TextareaField, {
-			props: { label: "x", value: "", state: "error", alertMessage: "bad" },
+			props: {
+				label: "x",
+				value: "",
+				state: "error",
+				alertMessage: "bad",
+			},
 		});
 		expect(w.find("textarea").attributes("aria-invalid")).toBe("true");
 		expect(w.find(".ep-input__alert--error").text()).toBe("bad");
@@ -58,7 +72,11 @@ describe("EpTextarea", () => {
 
 	it("has no axe violations", async () => {
 		const w = mount(TextareaField, {
-			props: { label: "Notes", value: "Hello", assistiveText: "Describe" },
+			props: {
+				label: "Notes",
+				value: "Hello",
+				assistiveText: "Describe",
+			},
 			attachTo: document.body,
 		});
 		await expectNoA11yViolations(w.element as HTMLElement);

--- a/packages/ecosphere/src/general/SVGIcon.story.vue
+++ b/packages/ecosphere/src/general/SVGIcon.story.vue
@@ -5,6 +5,8 @@ import SVGIcon from "./SVGIcon.vue";
 	<Story title="General/Icon">
 		<Variant title="Default"><SVGIcon name="ri-home-line" /></Variant>
 		<Variant title="Spin"><SVGIcon name="ri-loader-line" spin /></Variant>
-		<Variant title="Rotate 90"><SVGIcon name="ri-arrow-up-line" :rotate="90" /></Variant>
+		<Variant title="Rotate 90"
+			><SVGIcon name="ri-arrow-up-line" :rotate="90"
+		/></Variant>
 	</Story>
 </template>

--- a/packages/ecosphere/src/general/__tests__/SVGIcon.spec.ts
+++ b/packages/ecosphere/src/general/__tests__/SVGIcon.spec.ts
@@ -24,7 +24,9 @@ describe("EpIcon", () => {
 	});
 
 	it("applies spin class", () => {
-		const w = mount(SVGIcon, { props: { name: "ri-loader-line", spin: true } });
+		const w = mount(SVGIcon, {
+			props: { name: "ri-loader-line", spin: true },
+		});
 		expect(w.classes()).toContain("ep-icon--spin");
 	});
 
@@ -38,7 +40,7 @@ describe("EpIcon", () => {
 	it("does not apply rotate-0", () => {
 		const w = mount(SVGIcon, { props: { name: "ri-x", rotate: 0 } });
 		expect(w.classes().some((c) => c.startsWith("ep-icon--rotate-"))).toBe(
-			false,
+			false
 		);
 	});
 });

--- a/packages/ecosphere/src/miscellaneous/AvatarComponent.story.vue
+++ b/packages/ecosphere/src/miscellaneous/AvatarComponent.story.vue
@@ -4,7 +4,9 @@ import AvatarGroup from "./AvatarGroup.vue";
 </script>
 <template>
 	<Story title="Miscellaneous/Avatar">
-		<Variant title="Initials"><AvatarComponent name="Ada Lovelace" /></Variant>
+		<Variant title="Initials"
+			><AvatarComponent name="Ada Lovelace"
+		/></Variant>
 		<Variant title="Image">
 			<AvatarComponent name="Ada" image="https://i.pravatar.cc/100" />
 		</Variant>

--- a/packages/ecosphere/src/miscellaneous/AvatarComponent.vue
+++ b/packages/ecosphere/src/miscellaneous/AvatarComponent.vue
@@ -28,12 +28,7 @@ import { useEpSize } from "../composables/useEpSize";
 import type { EpSize } from "../general/config";
 import type { EpHue, EpShape } from "../utilities/types/shared";
 
-export type EpAvatarStatus =
-	| "default"
-	| "offline"
-	| "online"
-	| "away"
-	| "busy";
+export type EpAvatarStatus = "default" | "offline" | "online" | "away" | "busy";
 
 export interface AvatarProps {
 	/** Display name; first/last initials are derived when no image. */
@@ -65,7 +60,7 @@ watch(
 	() => props.image,
 	() => {
 		imageFailed.value = false;
-	},
+	}
 );
 
 function onImageError() {

--- a/packages/ecosphere/src/miscellaneous/AvatarGroup.vue
+++ b/packages/ecosphere/src/miscellaneous/AvatarGroup.vue
@@ -47,7 +47,10 @@ withDefaults(defineProps<AvatarGroupProps>(), {
 		height: 2rem;
 		padding-inline: 0.5rem;
 		border-radius: 999px;
-		background: var(--ep-color-background-faded, var(--ep-color-background));
+		background: var(
+			--ep-color-background-faded,
+			var(--ep-color-background)
+		);
 		color: var(--ep-color-contrast);
 		font-family: var(--ep-font-family-base);
 		font-size: 0.75rem;

--- a/packages/ecosphere/src/miscellaneous/StepperComponent.story.vue
+++ b/packages/ecosphere/src/miscellaneous/StepperComponent.story.vue
@@ -1,0 +1,41 @@
+<template>
+	<Story title="Miscellaneous/StepperComponent">
+		<Variant title="Horizontal">
+			<StepperComponent :value="1" :steps="steps" />
+		</Variant>
+		<Variant title="Vertical">
+			<StepperComponent
+				:value="2"
+				:steps="steps"
+				orientation="vertical"
+			/>
+		</Variant>
+		<Variant title="Error state">
+			<StepperComponent :value="1" :steps="steps" state="error" />
+		</Variant>
+		<Variant title="Progress dots + clickable">
+			<StepperComponent
+				v-model:value="current"
+				:steps="steps"
+				progress-dots
+				clickable
+			/>
+		</Variant>
+	</Story>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import StepperComponent, { type StepperStep } from "./StepperComponent.vue";
+
+const current = ref(0);
+const steps: StepperStep[] = [
+	{ label: "Step 1", description: "Install Ecosphere" },
+	{
+		label: "Step 2",
+		description: "Configure main.ts",
+		icon: "ri-home-2-line",
+	},
+	{ label: "Step 3", description: "You're all set!" },
+];
+</script>

--- a/packages/ecosphere/src/miscellaneous/StepperComponent.vue
+++ b/packages/ecosphere/src/miscellaneous/StepperComponent.vue
@@ -1,286 +1,399 @@
 <template>
-	<div
-		:id="stepperID"
-		class="stepper"
-		:class="`stepper--${responsiveOrientation}`"
+	<ol
+		:id="stepperId"
+		class="ep-stepper"
+		:class="[
+			`ep-stepper--${effectiveOrientation}`,
+			`ep-stepper--${size}`,
+			{
+				'ep-stepper--clickable': clickable,
+				'ep-stepper--progress-dots': progressDots,
+			},
+		]"
+		:aria-label="ariaLabel"
 	>
-		<div
+		<li
 			v-for="(step, index) in steps"
-			class="step"
+			:key="index"
+			class="ep-stepper__step"
 			:class="[
-				`step--${responsiveOrientation}`,
-				index <= current
-					? `step-completed step-completed--${responsiveOrientation}`
-					: '',
+				`ep-stepper__step--${effectiveOrientation}`,
+				`ep-stepper__step--${stepHue(index)}`,
+				{
+					'ep-stepper__step--complete': index < value,
+					'ep-stepper__step--current': index === value,
+					'ep-stepper__step--pending': index > value,
+				},
 			]"
+			:aria-current="index === value ? 'step' : undefined"
 		>
-			<div class="step__icon" :class="[`step__icon--${stepHue(index)}`]">
+			<component
+				:is="clickable ? 'button' : 'div'"
+				class="ep-stepper__indicator"
+				:type="clickable ? 'button' : undefined"
+				:tabindex="clickable ? 0 : undefined"
+				:aria-label="
+					clickable
+						? `Go to step ${index + 1}: ${step.label}`
+						: undefined
+				"
+				:disabled="clickable && !canClick(index) ? true : undefined"
+				@click="onStepClick(index)"
+				@keydown.enter.prevent="onStepClick(index)"
+				@keydown.space.prevent="onStepClick(index)"
+			>
 				<SVGIcon
 					v-if="
-						index < current ||
-						(index === current && state === 'completed')
+						index < value ||
+						(index === value && state === 'completed')
 					"
 					name="ri-check-line"
-				></SVGIcon>
+				/>
 				<SVGIcon
-					v-else-if="index === current && state === 'error'"
+					v-else-if="index === value && state === 'error'"
 					name="ri-close-line"
-				></SVGIcon>
+				/>
 				<SVGIcon
-					v-else-if="index === current && state === 'warning'"
+					v-else-if="index === value && state === 'warning'"
 					name="ri-error-warning-line"
-				></SVGIcon>
-				<SVGIcon v-else-if="step.icon" :name="step.icon"></SVGIcon
-				><span v-else>{{ index + 1 }}</span>
-			</div>
+				/>
+				<SVGIcon v-else-if="step.icon" :name="step.icon" />
+				<span v-else>{{ index + 1 }}</span>
+			</component>
 			<div
-				class="step__details"
-				:class="`step__details--${responsiveOrientation}`"
+				class="ep-stepper__details"
+				:class="`ep-stepper__details--${effectiveOrientation}`"
 			>
-				<div
-					class="step__label"
-					:class="[
-						current === index ? `step__label--${state}` : '',
-						`step__label--${stepHue(index)}`,
-					]"
-				>
-					{{ step.label }}
-				</div>
-				<div
-					class="step__description"
-					:class="`step__description--${responsiveOrientation}`"
-				>
+				<div class="ep-stepper__label">{{ step.label }}</div>
+				<div v-if="step.description" class="ep-stepper__description">
 					{{ step.description }}
 				</div>
 			</div>
-		</div>
-	</div>
+			<div
+				v-if="index < steps.length - 1"
+				class="ep-stepper__connector"
+				:class="[
+					`ep-stepper__connector--${effectiveOrientation}`,
+					{
+						'ep-stepper__connector--complete': index < value,
+					},
+				]"
+				aria-hidden="true"
+			/>
+		</li>
+	</ol>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
-import type { PropType } from "vue";
-import type {
-	hue_limited,
-	stepper_step,
-	stepper_orientation,
-	stepper_state,
-	hue,
-} from "../utilities/types.interface";
-import {
-	hue_limited_options,
-	stepper_orientation_options,
-	stepper_state_options,
-} from "../utilities/types.interface";
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import SVGIcon from "../general/SVGIcon.vue";
+import { useEpSize } from "../composables/useEpSize";
+import { useEpId } from "../composables/useEpId";
+import type { EpSize } from "../general/config";
+import type { EpHue } from "../utilities/types/shared";
 
-export default defineComponent({
-	name: "StepperComponent",
-	components: {
-		SVGIcon,
-	},
-	props: {
-		current: {
-			type: Number as PropType<number>,
-			default: 0,
-		},
-		hue: {
-			type: String as PropType<hue_limited>,
-			default: "information",
-			validator(value: hue_limited): boolean {
-				return hue_limited_options.includes(value);
-			},
-		},
-		steps: {
-			type: Array as PropType<stepper_step[]>,
-			required: true,
-		},
-		orientation: {
-			type: String as PropType<stepper_orientation>,
-			default: "horizontal",
-			validator(value: stepper_orientation): boolean {
-				return stepper_orientation_options.includes(value);
-			},
-		},
-		state: {
-			type: String as PropType<stepper_state>,
-			default: "in-progress",
-			validator(value: stepper_state): boolean {
-				return stepper_state_options.includes(value);
-			},
-		},
-		responsive: {
-			type: Boolean as PropType<boolean>,
-			default: true,
-		},
-	},
-	data() {
-		return {
-			stepperID: `eco-stepper-${Date.now()
-				.toString()
-				.slice(8)}-${Math.random().toFixed(5).slice(2)}`,
-			allowHorizontal: false,
-		};
-	},
-	computed: {
-		responsiveOrientation(): stepper_orientation {
-			if (this.orientation === "horizontal" && this.responsive) {
-				if (!this.allowHorizontal) {
-					return "vertical";
-				}
-			}
-			return this.orientation;
-		},
-	},
-	beforeMount() {
-		window.addEventListener("resize", this.assessHorizontalCapability);
-	},
-	mounted() {
-		this.assessHorizontalCapability();
-	},
-	beforeUnmount() {
-		window.removeEventListener("resize", this.assessHorizontalCapability);
-	},
-	methods: {
-		stepHue(index: number): hue | "default" {
-			if (index < this.current) {
+export type StepperOrientation = "horizontal" | "vertical";
+export type StepperState =
+	| "awaiting"
+	| "in-progress"
+	| "completed"
+	| "error"
+	| "warning";
+
+export interface StepperStep {
+	label: string;
+	description?: string;
+	icon?: string;
+}
+
+export interface StepperProps {
+	value?: number;
+	steps: StepperStep[];
+	hue?: EpHue;
+	orientation?: StepperOrientation;
+	state?: StepperState;
+	responsive?: boolean;
+	clickable?: boolean;
+	progressDots?: boolean;
+	size?: EpSize;
+	ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<StepperProps>(), {
+	value: 0,
+	hue: "information",
+	orientation: "horizontal",
+	state: "in-progress",
+	responsive: true,
+	clickable: false,
+	progressDots: false,
+	size: undefined,
+	ariaLabel: "Progress",
+});
+
+const emit = defineEmits<{
+	(e: "update:value", value: number): void;
+	(e: "change", value: number, step: StepperStep): void;
+}>();
+
+const stepperId = useEpId("ep-stepper");
+const size = useEpSize(() => props.size);
+const allowHorizontal = ref(true);
+
+const effectiveOrientation = computed<StepperOrientation>(() => {
+	if (
+		props.orientation === "horizontal" &&
+		props.responsive &&
+		!allowHorizontal.value
+	) {
+		return "vertical";
+	}
+	return props.orientation;
+});
+
+function stepHue(index: number): EpHue | "default" {
+	if (index < props.value) return "success";
+	if (index === props.value) {
+		switch (props.state) {
+			case "awaiting":
+				return "default";
+			case "in-progress":
+				return props.hue;
+			case "completed":
 				return "success";
-			} else if (index <= this.current) {
-				switch (this.state) {
-					case "awaiting":
-						return "default";
-					case "in-progress":
-						return this.hue;
-					case "completed":
-						return "success";
-					case "warning":
-						return "warning";
-					case "error":
-						return "error";
-					default:
-						break;
-				}
-				return "information";
-			}
-			return "default";
-		},
-		assessHorizontalCapability(): void {
-			const containerWidth: number =
-				document.getElementById(this.stepperID)?.getBoundingClientRect()
-					.width || 0;
-			const minimumRequiredHorizontalWidth = 150 * this.steps.length + 50;
-			if (containerWidth < minimumRequiredHorizontalWidth) {
-				this.allowHorizontal = false;
-			} else {
-				this.allowHorizontal = true;
-			}
-		},
-	},
+			case "warning":
+				return "warning";
+			case "error":
+				return "error";
+		}
+	}
+	return "default";
+}
+
+function canClick(index: number): boolean {
+	return props.clickable && index <= props.value + 1;
+}
+
+function onStepClick(index: number) {
+	if (!props.clickable || !canClick(index)) return;
+	emit("update:value", index);
+	emit("change", index, props.steps[index]);
+}
+
+function assessHorizontalCapability() {
+	if (typeof document === "undefined") return;
+	const el = document.getElementById(stepperId);
+	if (!el) return;
+	const width = el.getBoundingClientRect().width || 0;
+	const minWidth = 150 * props.steps.length + 50;
+	allowHorizontal.value = width >= minWidth;
+}
+
+onMounted(() => {
+	assessHorizontalCapability();
+	if (typeof window !== "undefined") {
+		window.addEventListener("resize", assessHorizontalCapability);
+	}
+});
+
+onBeforeUnmount(() => {
+	if (typeof window !== "undefined") {
+		window.removeEventListener("resize", assessHorizontalCapability);
+	}
 });
 </script>
 
-<style lang="scss" scoped>
-.stepper {
+<style scoped>
+.ep-stepper {
+	list-style: none;
+	margin: 0;
+	padding: 0;
 	display: grid;
 	width: 100%;
-
-	&--horizontal {
-		grid-auto-columns: minmax(0, 1fr);
-		grid-auto-flow: column;
-		column-gap: 1rem;
-	}
-
-	&--vertical {
-		grid-auto-flow: row;
-		grid-auto-columns: 1fr;
-		row-gap: 1.5rem;
-	}
+	font-family: var(--ep-font-family-base);
+	color: var(--ep-color-contrast);
 }
 
-.step {
+.ep-stepper--horizontal {
+	grid-auto-flow: column;
+	grid-auto-columns: minmax(0, 1fr);
+	column-gap: 0;
+}
+
+.ep-stepper--vertical {
+	grid-auto-flow: row;
+	row-gap: 1.25rem;
+}
+
+.ep-stepper--xs {
+	font-size: 0.75rem;
+}
+.ep-stepper--sm {
+	font-size: 0.875rem;
+}
+.ep-stepper--md {
+	font-size: 1rem;
+}
+.ep-stepper--lg {
+	font-size: 1.125rem;
+}
+.ep-stepper--xl {
+	font-size: 1.25rem;
+}
+
+.ep-stepper__step {
+	position: relative;
+	min-width: 0;
+}
+
+.ep-stepper__step--horizontal {
+	display: flex;
+	flex-direction: column;
 	align-items: center;
-	min-width: 150px;
-
-	&--horizontal {
-		display: flex;
-		flex-direction: column;
-	}
-
-	&--vertical {
-		display: grid;
-		grid-template-columns: min-content 1fr;
-		column-gap: 0.5rem;
-	}
-
-	&__icon {
-		background: $color-offline;
-		border-radius: 50%;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: 2rem;
-		width: 2rem;
-		@include font-bold;
-		@include hue-modifiers;
-		border: 1px solid $color-transparent;
-
-		&--default {
-			border: 1px solid $color-divider;
-			color: $color-dark-faded;
-		}
-	}
-
-	&__details {
-		display: flex;
-		flex-direction: column;
-
-		&--horizontal {
-			align-items: center;
-		}
-	}
-
-	&__label {
-		@include font-bold;
-		@include hue-color-modifiers;
-		color: $color-disabled;
-	}
-
-	&__description {
-		@include font-footnote;
-
-		&--horizontal {
-			text-align: center;
-		}
-	}
+	row-gap: 0.5rem;
 }
 
-.step + .step--horizontal:after {
-	content: "";
+.ep-stepper__step--vertical {
+	display: grid;
+	grid-template-columns: min-content 1fr;
+	column-gap: 0.75rem;
+}
+
+.ep-stepper__indicator {
+	appearance: none;
+	border: 1px solid var(--ep-color-transparent);
+	background: var(--ep-color-background-faded);
+	color: var(--ep-color-contrast);
+	height: 2rem;
+	width: 2rem;
+	min-width: 2rem;
+	border-radius: 50%;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: 600;
+	cursor: default;
+	transition: var(--ep-transition-base);
+	font-family: inherit;
+}
+
+.ep-stepper--progress-dots .ep-stepper__indicator {
+	height: 0.75rem;
+	width: 0.75rem;
+	min-width: 0.75rem;
+	font-size: 0;
+}
+
+.ep-stepper--progress-dots .ep-stepper__indicator > * {
+	display: none;
+}
+
+.ep-stepper--clickable .ep-stepper__indicator {
+	cursor: pointer;
+}
+
+.ep-stepper--clickable .ep-stepper__indicator:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: 2px;
+}
+
+.ep-stepper--clickable .ep-stepper__indicator:disabled {
+	cursor: not-allowed;
+}
+
+.ep-stepper__step--primary .ep-stepper__indicator {
+	background: var(--ep-color-primary);
+	color: var(--ep-color-primary-contrast);
+}
+.ep-stepper__step--primary-variant .ep-stepper__indicator {
+	background: var(--ep-color-primary-variant);
+	color: var(--ep-color-primary-variant-contrast);
+}
+.ep-stepper__step--secondary .ep-stepper__indicator {
+	background: var(--ep-color-secondary);
+	color: var(--ep-color-secondary-contrast);
+}
+.ep-stepper__step--secondary-variant .ep-stepper__indicator {
+	background: var(--ep-color-secondary-variant);
+	color: var(--ep-color-secondary-variant-contrast);
+}
+.ep-stepper__step--error .ep-stepper__indicator {
+	background: var(--ep-color-error);
+	color: var(--ep-color-contrast);
+}
+.ep-stepper__step--success .ep-stepper__indicator {
+	background: var(--ep-color-success);
+	color: var(--ep-color-contrast);
+}
+.ep-stepper__step--warning .ep-stepper__indicator {
+	background: var(--ep-color-warning);
+	color: var(--ep-color-contrast);
+}
+.ep-stepper__step--information .ep-stepper__indicator {
+	background: var(--ep-color-information);
+	color: var(--ep-color-contrast);
+}
+.ep-stepper__step--default .ep-stepper__indicator {
+	background: var(--ep-color-background-faded);
+	color: var(--ep-color-contrast);
+	border: 1px solid var(--ep-color-divider);
+	opacity: 0.7;
+}
+
+.ep-stepper__details {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.ep-stepper__details--horizontal {
+	align-items: center;
+	text-align: center;
+}
+
+.ep-stepper__label {
+	font-weight: 600;
+}
+
+.ep-stepper__step--pending .ep-stepper__label {
+	opacity: 0.6;
+}
+
+.ep-stepper__description {
+	font-size: 0.875em;
+	opacity: 0.7;
+}
+
+.ep-stepper__connector {
+	background: var(--ep-color-divider);
+	z-index: 0;
+}
+
+.ep-stepper__connector--horizontal {
 	position: absolute;
-	transform: translateX(-50%);
 	top: 1rem;
-	background: $color-divider;
-	height: 1px;
+	left: 50%;
 	width: 100%;
-	z-index: -1;
+	height: 1px;
 }
 
-.step-completed + .step-completed--horizontal:after {
-	background: $color-success;
+.ep-stepper--progress-dots .ep-stepper__connector--horizontal {
+	top: 0.375rem;
 }
 
-.step + .step--vertical:after {
-	content: "";
+.ep-stepper__connector--vertical {
 	position: absolute;
-	transform: translateY(-2rem);
 	left: 1rem;
-	background: $color-divider;
-	height: 100%;
+	top: 2rem;
+	height: calc(100% + 1.25rem - 2rem);
 	width: 1px;
-	z-index: -1;
 }
 
-.step-completed + .step-completed--vertical:after {
-	background: $color-success;
+.ep-stepper--progress-dots .ep-stepper__connector--vertical {
+	left: 0.375rem;
+}
+
+.ep-stepper__connector--complete {
+	background: var(--ep-color-success);
 }
 </style>

--- a/packages/ecosphere/src/miscellaneous/TagComponent.story.vue
+++ b/packages/ecosphere/src/miscellaneous/TagComponent.story.vue
@@ -4,7 +4,11 @@ import TagComponent from "./TagComponent.vue";
 <template>
 	<Story title="Miscellaneous/Tag">
 		<Variant title="Default"><TagComponent label="Tag" /></Variant>
-		<Variant title="Closable"><TagComponent label="Removable" closable /></Variant>
-		<Variant title="Bordered"><TagComponent label="Bordered" bordered hue="error" /></Variant>
+		<Variant title="Closable"
+			><TagComponent label="Removable" closable
+		/></Variant>
+		<Variant title="Bordered"
+			><TagComponent label="Bordered" bordered hue="error"
+		/></Variant>
 	</Story>
 </template>

--- a/packages/ecosphere/src/miscellaneous/__tests__/AvatarComponent.spec.ts
+++ b/packages/ecosphere/src/miscellaneous/__tests__/AvatarComponent.spec.ts
@@ -66,7 +66,7 @@ describe("EpAvatar", () => {
 describe("EpAvatarGroup", () => {
 	it("renders default slot inside a group", () => {
 		const w = mount(AvatarGroup, {
-			slots: { default: "<span class=\"x\"></span>" },
+			slots: { default: '<span class="x"></span>' },
 		});
 		expect(w.attributes("role")).toBe("group");
 		expect(w.find(".x").exists()).toBe(true);

--- a/packages/ecosphere/src/miscellaneous/__tests__/StepperComponent.spec.ts
+++ b/packages/ecosphere/src/miscellaneous/__tests__/StepperComponent.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import StepperComponent, { type StepperStep } from "../StepperComponent.vue";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+const steps: StepperStep[] = [
+	{ label: "Install" },
+	{ label: "Configure" },
+	{ label: "Use" },
+];
+
+describe("EpStepper", () => {
+	it("renders ordered list with aria-label", () => {
+		const w = mount(StepperComponent, { props: { steps, value: 0 } });
+		expect(w.find("ol").exists()).toBe(true);
+		expect(w.find("ol").attributes("aria-label")).toBe("Progress");
+	});
+
+	it("renders one step per item", () => {
+		const w = mount(StepperComponent, { props: { steps, value: 0 } });
+		expect(w.findAll(".ep-stepper__step").length).toBe(steps.length);
+	});
+
+	it("marks current step with aria-current=step", () => {
+		const w = mount(StepperComponent, { props: { steps, value: 1 } });
+		const items = w.findAll(".ep-stepper__step");
+		expect(items[0].attributes("aria-current")).toBeUndefined();
+		expect(items[1].attributes("aria-current")).toBe("step");
+		expect(items[2].attributes("aria-current")).toBeUndefined();
+	});
+
+	it("clickable mode emits update:value", async () => {
+		const w = mount(StepperComponent, {
+			props: { steps, value: 0, clickable: true },
+		});
+		await w.findAll(".ep-stepper__indicator")[1].trigger("click");
+		expect(w.emitted("update:value")?.[0]).toEqual([1]);
+		expect(w.emitted("change")?.[0]?.[0]).toBe(1);
+	});
+
+	it("non-clickable mode does not emit", async () => {
+		const w = mount(StepperComponent, { props: { steps, value: 0 } });
+		await w.findAll(".ep-stepper__indicator")[1].trigger("click");
+		expect(w.emitted("update:value")).toBeFalsy();
+	});
+
+	it("error state shows error icon on current step", () => {
+		const w = mount(StepperComponent, {
+			props: { steps, value: 1, state: "error" },
+		});
+		const items = w.findAll(".ep-stepper__step");
+		expect(items[1].classes()).toContain("ep-stepper__step--error");
+	});
+
+	it("progressDots applies dot modifier class", () => {
+		const w = mount(StepperComponent, {
+			props: { steps, value: 0, progressDots: true },
+		});
+		expect(w.find("ol").classes()).toContain("ep-stepper--progress-dots");
+	});
+
+	it("has no axe violations", async () => {
+		const w = mount(StepperComponent, {
+			props: { steps, value: 1 },
+			attachTo: document.body,
+		});
+		await expectNoA11yViolations(w.element as HTMLElement);
+		w.unmount();
+	});
+});

--- a/packages/ecosphere/src/miscellaneous/__tests__/TagComponent.spec.ts
+++ b/packages/ecosphere/src/miscellaneous/__tests__/TagComponent.spec.ts
@@ -66,7 +66,7 @@ describe("EpTag", () => {
 			props: { label: "x", closable: true, closeLabel: "Dismiss tag" },
 		});
 		expect(w.find(".ep-tag__close").attributes("aria-label")).toBe(
-			"Dismiss tag",
+			"Dismiss tag"
 		);
 	});
 

--- a/packages/ecosphere/src/navigation/BreadcrumbNavigation.story.vue
+++ b/packages/ecosphere/src/navigation/BreadcrumbNavigation.story.vue
@@ -1,0 +1,37 @@
+<template>
+	<Story title="Navigation/BreadcrumbNavigation">
+		<Variant title="Default">
+			<BreadcrumbNavigation :items="items" />
+		</Variant>
+		<Variant title="Bordered">
+			<BreadcrumbNavigation :items="items" bordered />
+		</Variant>
+		<Variant title="With icons + custom separator">
+			<BreadcrumbNavigation :items="iconItems">
+				<template #separator>
+					<span>/</span>
+				</template>
+			</BreadcrumbNavigation>
+		</Variant>
+		<Variant title="Disabled">
+			<BreadcrumbNavigation :items="items" disabled />
+		</Variant>
+	</Story>
+</template>
+
+<script setup lang="ts">
+import BreadcrumbNavigation, {
+	type BreadcrumbItem,
+} from "./BreadcrumbNavigation.vue";
+
+const items: BreadcrumbItem[] = [
+	{ label: "Home", href: "/" },
+	{ label: "Library", href: "/library" },
+	{ label: "Data", active: true },
+];
+const iconItems: BreadcrumbItem[] = [
+	{ label: "Home", icon: "ri-home-line", href: "/" },
+	{ label: "Navigation", icon: "ri-navigation-line", disabled: true },
+	{ label: "Breadcrumb", active: true },
+];
+</script>

--- a/packages/ecosphere/src/navigation/BreadcrumbNavigation.vue
+++ b/packages/ecosphere/src/navigation/BreadcrumbNavigation.vue
@@ -1,151 +1,248 @@
 <template>
-	<div
-		class="breadcrumb"
-		:class="{ 'breadcrumb--outline': outline, 'breadcrumb--expand': !wrap }"
+	<nav
+		class="ep-breadcrumb"
+		:class="[
+			`ep-breadcrumb--${size}`,
+			{
+				'ep-breadcrumb--bordered': bordered,
+				'ep-breadcrumb--scroll': !wrap,
+				'ep-breadcrumb--disabled': disabled,
+			},
+		]"
+		:aria-label="ariaLabel"
 	>
-		<div
-			v-for="option in renderOptions"
-			class="breadcrumb__item"
-			:class="[
-				{
-					'breadcrumb__item--active': option.active,
-					'breadcrumb__item--disabled': option.disabled || disabled,
-				},
-			]"
-			:tabindex="option.disabled ? -1 : 0"
-			@click="handleClick(option)"
-		>
-			<SVGIcon
-				v-if="option.icon"
-				class="breadcrumb__item-icon"
-				:name="option.icon"
-			></SVGIcon>
-			<div class="breadcrumb__item-label">{{ option.label }}</div>
-		</div>
-	</div>
+		<ol class="ep-breadcrumb__list">
+			<template v-for="(item, index) in visibleItems" :key="index">
+				<li
+					v-if="index > 0"
+					class="ep-breadcrumb__separator"
+					aria-hidden="true"
+				>
+					<slot name="separator" :index="index">
+						<SVGIcon :name="dividerIcon" />
+					</slot>
+				</li>
+				<li
+					class="ep-breadcrumb__item"
+					:class="{
+						'ep-breadcrumb__item--active': item.active,
+						'ep-breadcrumb__item--disabled':
+							item.disabled || disabled,
+					}"
+				>
+					<slot name="item" :item="item" :index="index">
+						<component
+							:is="
+								item.active || item.disabled || disabled
+									? 'span'
+									: 'a'
+							"
+							class="ep-breadcrumb__link"
+							:href="
+								item.active || item.disabled || disabled
+									? undefined
+									: (item.href ?? '#')
+							"
+							:aria-current="item.active ? 'page' : undefined"
+							:aria-disabled="
+								item.disabled || disabled ? 'true' : undefined
+							"
+							:tabindex="
+								item.active || item.disabled || disabled
+									? undefined
+									: 0
+							"
+							@click="onItemClick($event, item)"
+							@keydown.enter.prevent="onItemActivate(item)"
+							@keydown.space.prevent="onItemActivate(item)"
+						>
+							<SVGIcon
+								v-if="item.icon"
+								class="ep-breadcrumb__icon"
+								:name="item.icon"
+								aria-hidden="true"
+							/>
+							<span class="ep-breadcrumb__label">{{
+								item.label
+							}}</span>
+						</component>
+					</slot>
+				</li>
+			</template>
+		</ol>
+	</nav>
 </template>
 
-<script lang="ts">
-import { defineComponent, type PropType } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import SVGIcon from "../general/SVGIcon.vue";
-import type {
-	breadcrumb_item,
-	breadcrumb_item_compiled,
-} from "../utilities/types.interface";
+import { useEpSize } from "../composables/useEpSize";
+import type { EpSize } from "../general/config";
 
-export default defineComponent({
-	name: "BreadcrumbNavigation",
-	components: {
-		SVGIcon,
-	},
-	props: {
-		options: {
-			type: Array as PropType<breadcrumb_item[]>,
-			required: true,
-		},
-		disabled: {
-			type: Boolean as PropType<boolean>,
-			default: false,
-		},
-		outline: {
-			type: Boolean as PropType<boolean>,
-			default: false,
-		},
-		wrap: {
-			type: Boolean as PropType<boolean>,
-			default: false,
-		},
-		dividerIcon: {
-			type: String as PropType<string>,
-			default: "ri-arrow-right-s-line",
-		},
-	},
-	computed: {
-		renderOptions(): breadcrumb_item_compiled[] {
-			const filtered_options = this.options
-				.filter((option: breadcrumb_item) => !option.hidden)
-				.map((option: breadcrumb_item): breadcrumb_item_compiled => {
-					return {
-						...option,
-						type: "item",
-					};
-				});
-			const options: breadcrumb_item_compiled[] = [];
-			for (let index = 0; index < filtered_options.length; index++) {
-				if (index !== 0) {
-					options.push({
-						type: "divider",
-						icon: this.dividerIcon,
-						disabled: true,
-					});
-				}
-				options.push(filtered_options[index]);
-			}
-			return options;
-		},
-	},
-	methods: {
-		handleClick(option: breadcrumb_item): void {
-			if (option.action) {
-				option.action();
-			}
-		},
-	},
+export interface BreadcrumbItem {
+	label?: string;
+	icon?: string;
+	href?: string;
+	hidden?: boolean;
+	disabled?: boolean;
+	active?: boolean;
+	action?: () => void;
+}
+
+export interface BreadcrumbProps {
+	items: BreadcrumbItem[];
+	disabled?: boolean;
+	bordered?: boolean;
+	wrap?: boolean;
+	dividerIcon?: string;
+	size?: EpSize;
+	ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<BreadcrumbProps>(), {
+	disabled: false,
+	bordered: false,
+	wrap: true,
+	dividerIcon: "ri-arrow-right-s-line",
+	size: undefined,
+	ariaLabel: "Breadcrumb",
 });
+
+const emit = defineEmits<{
+	(e: "select", item: BreadcrumbItem, index: number): void;
+}>();
+
+const size = useEpSize(() => props.size);
+const visibleItems = computed(() => props.items.filter((i) => !i.hidden));
+
+function onItemActivate(item: BreadcrumbItem) {
+	if (item.active || item.disabled || props.disabled) return;
+	item.action?.();
+	const idx = visibleItems.value.indexOf(item);
+	emit("select", item, idx);
+}
+
+function onItemClick(e: MouseEvent, item: BreadcrumbItem) {
+	if (!item.href || item.href === "#") {
+		e.preventDefault();
+	}
+	onItemActivate(item);
+}
 </script>
 
-<style lang="scss" scoped>
-.breadcrumb {
+<style scoped>
+.ep-breadcrumb {
+	display: block;
+	width: fit-content;
+	max-width: 100%;
+	color: var(--ep-color-contrast);
+	font-family: var(--ep-font-family-base);
+}
+
+.ep-breadcrumb--bordered {
+	padding: 0.25rem 0.5rem;
+	border-radius: var(--ep-radius-base);
+	border: 1px solid var(--ep-color-divider);
+}
+
+.ep-breadcrumb--scroll {
+	overflow-x: auto;
+	padding-bottom: 0.25rem;
+}
+
+.ep-breadcrumb--disabled {
+	opacity: 0.5;
+	pointer-events: none;
+}
+
+.ep-breadcrumb--xs {
+	font-size: 0.75rem;
+}
+.ep-breadcrumb--sm {
+	font-size: 0.875rem;
+}
+.ep-breadcrumb--md {
+	font-size: 1rem;
+}
+.ep-breadcrumb--lg {
+	font-size: 1.125rem;
+}
+.ep-breadcrumb--xl {
+	font-size: 1.25rem;
+}
+
+.ep-breadcrumb__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
 	display: flex;
 	flex-direction: row;
-	flex-wrap: wrap;
 	align-items: center;
+	flex-wrap: wrap;
 	column-gap: 0.25rem;
 	row-gap: 0.25rem;
-	@include font-light;
-	width: fit-content;
+}
 
-	&--expand {
-		flex-wrap: nowrap;
-		max-width: 100%;
-		padding-bottom: 0.5rem;
-		overflow-x: auto;
-	}
+.ep-breadcrumb--scroll .ep-breadcrumb__list {
+	flex-wrap: nowrap;
+}
 
-	&--outline {
-		padding: 0.25rem 0.5rem;
-		border-radius: $border-radius-standard;
-		border: 1px solid $color-divider;
-	}
+.ep-breadcrumb__separator {
+	display: inline-flex;
+	align-items: center;
+	opacity: 0.5;
+	font-size: 1em;
+}
 
-	&__item {
-		cursor: pointer;
-		transition: $transition-standard;
-		padding: 0 0.25rem;
-		border-radius: $border-radius-standard;
-		display: flex;
-		flex-direction: row;
-		flex-wrap: nowrap;
-		column-gap: 0.25rem;
-		align-items: center;
+.ep-breadcrumb__item {
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+}
 
-		&:hover {
-			color: $color-hyperlink;
-		}
+.ep-breadcrumb__item--disabled {
+	opacity: 0.5;
+}
 
-		&:focus {
-			outline: $outline-focus;
-		}
+.ep-breadcrumb__link {
+	display: inline-flex;
+	align-items: center;
+	column-gap: 0.25rem;
+	padding: 0 0.25rem;
+	border-radius: var(--ep-radius-base);
+	color: inherit;
+	text-decoration: none;
+	cursor: pointer;
+	transition: var(--ep-transition-base);
+	white-space: nowrap;
+}
 
-		&--active {
-			@include font-bold;
-		}
+.ep-breadcrumb__link:hover:not([aria-disabled="true"]):not([aria-current]) {
+	color: var(--ep-color-information);
+}
 
-		&--disabled {
-			opacity: 0.5;
-			color: $color-disabled;
-			pointer-events: none;
-		}
-	}
+.ep-breadcrumb__link:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: 2px;
+}
+
+.ep-breadcrumb__link[aria-current="page"] {
+	cursor: default;
+	font-weight: 600;
+}
+
+.ep-breadcrumb__link[aria-disabled="true"] {
+	cursor: not-allowed;
+	pointer-events: none;
+}
+
+.ep-breadcrumb__icon {
+	font-size: 1em;
+}
+
+.ep-breadcrumb__label {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 </style>

--- a/packages/ecosphere/src/navigation/MenuNavigation.story.vue
+++ b/packages/ecosphere/src/navigation/MenuNavigation.story.vue
@@ -1,0 +1,28 @@
+<template>
+	<Story title="Navigation/MenuNavigation">
+		<Variant title="Inline (default)">
+			<MenuNavigation :options="options" />
+		</Variant>
+		<Variant title="Horizontal">
+			<MenuNavigation :options="options" mode="horizontal" />
+		</Variant>
+		<Variant title="Collapsed">
+			<MenuNavigation :options="options" collapsed />
+		</Variant>
+	</Story>
+</template>
+
+<script setup lang="ts">
+import MenuNavigation, { type MenuItemData } from "./MenuNavigation.vue";
+
+const options: MenuItemData[] = [
+	{ label: "Home", icon: "ri-home-line", active: true },
+	{
+		label: "Products",
+		icon: "ri-box-3-line",
+		children: [{ label: "Plants" }, { label: "Seeds" }],
+	},
+	{ label: "About", icon: "ri-information-line" },
+	{ label: "Disabled", icon: "ri-lock-line", disabled: true },
+];
+</script>

--- a/packages/ecosphere/src/navigation/MenuNavigation.vue
+++ b/packages/ecosphere/src/navigation/MenuNavigation.vue
@@ -1,62 +1,86 @@
 <template>
-	<div class="menu">
+	<ul
+		class="ep-menu"
+		:class="[`ep-menu--${size}`, `ep-menu--${mode}`]"
+		role="menu"
+		:aria-label="ariaLabel"
+	>
 		<MenuItem
-			v-for="option in options"
+			v-for="(option, idx) in options"
+			:key="idx"
 			:option="option"
-			:skeleton="skeleton"
 			:hue="hue"
-			:theme="theme"
-		></MenuItem>
-	</div>
+			:skeleton="skeleton"
+			:collapsed="collapsed"
+		/>
+	</ul>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
-import type { PropType } from "vue";
-import type { menu_item, hue, theme } from "../utilities/types.interface";
-import { hue_options, theme_options } from "../utilities/types.interface";
-import MenuItem from "./MenuNavigation/MenuItem.vue";
+<script setup lang="ts">
+import MenuItem, { type MenuItemData } from "./MenuNavigation/MenuItem.vue";
+import { useEpSize } from "../composables/useEpSize";
+import type { EpSize } from "../general/config";
+import type { EpHue } from "../utilities/types/shared";
 
-export default defineComponent({
-	name: "MenuNavigation",
-	components: {
-		MenuItem,
-	},
-	props: {
-		options: {
-			type: Array as PropType<menu_item[]>,
-			required: true,
-		},
-		skeleton: {
-			type: Boolean as PropType<boolean>,
-			default: true,
-		},
-		hue: {
-			type: String as PropType<hue>,
-			default: "information",
-			validator(value: hue): boolean {
-				return hue_options.includes(value);
-			},
-		},
-		theme: {
-			type: String as PropType<theme>,
-			default: "auto",
-			validator(value: theme): boolean {
-				return theme_options.includes(value);
-			},
-		},
-	},
+export type MenuMode = "inline" | "vertical" | "horizontal";
+
+export interface MenuProps {
+	options: MenuItemData[];
+	mode?: MenuMode;
+	hue?: EpHue;
+	size?: EpSize;
+	skeleton?: boolean;
+	collapsed?: boolean;
+	ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<MenuProps>(), {
+	mode: "inline",
+	hue: "information",
+	size: undefined,
+	skeleton: true,
+	collapsed: false,
+	ariaLabel: "Menu",
 });
+
+const size = useEpSize(() => props.size);
+export type { MenuItemData };
 </script>
 
-<style lang="scss" scoped>
-.menu {
-	background: $color-background;
-	color: $color-contrast;
+<style scoped>
+.ep-menu {
+	list-style: none;
+	margin: 0;
+	padding: 0.25rem;
+	background: var(--ep-color-background);
+	color: var(--ep-color-contrast);
+	font-family: var(--ep-font-family-base);
+	border-radius: var(--ep-radius-base);
 	display: flex;
 	flex-direction: column;
-	row-gap: 0.25rem;
-	padding: 0.25rem;
-	border-radius: $border-radius-standard;
+	row-gap: 0.15rem;
+}
+
+.ep-menu--horizontal {
+	flex-direction: row;
+	column-gap: 0.25rem;
+	row-gap: 0;
+	flex-wrap: wrap;
+}
+
+.ep-menu--xs {
+	font-size: 0.75rem;
+}
+.ep-menu--sm {
+	font-size: 0.875rem;
+}
+.ep-menu--md {
+	font-size: 1rem;
+}
+.ep-menu--lg {
+	font-size: 1.125rem;
+}
+.ep-menu--xl {
+	font-size: 1.25rem;
 }
 </style>

--- a/packages/ecosphere/src/navigation/MenuNavigation/MenuItem.vue
+++ b/packages/ecosphere/src/navigation/MenuNavigation/MenuItem.vue
@@ -1,198 +1,262 @@
 <template>
-	<div
-		v-if="!option.hidden"
-		class="menu-item"
-		tabindex="0"
-		@click="handleClick"
-		@keypress.enter="handleClick"
-	>
-		<SVGIcon
-			v-if="option.icon"
-			class="menu-item__icon"
-			:name="option.icon"
-		></SVGIcon>
-		<div class="menu-item__label">{{ option.label }}</div>
-		<div class="menu-item__indicators">
+	<li v-if="!option.hidden" class="ep-menu-item" role="none">
+		<component
+			:is="option.children ? 'button' : option.href ? 'a' : 'button'"
+			class="ep-menu-item__trigger"
+			:class="[
+				{
+					'ep-menu-item__trigger--active': option.active,
+					'ep-menu-item__trigger--disabled': option.disabled,
+					'ep-menu-item__trigger--collapsed':
+						collapsed && depth === 0,
+				},
+			]"
+			:role="option.children ? 'menuitem' : 'menuitem'"
+			:href="!option.children && option.href ? option.href : undefined"
+			:type="!option.href ? 'button' : undefined"
+			:aria-haspopup="option.children ? 'menu' : undefined"
+			:aria-expanded="
+				option.children ? (showChildren ? 'true' : 'false') : undefined
+			"
+			:aria-current="option.active ? 'page' : undefined"
+			:aria-disabled="option.disabled ? 'true' : undefined"
+			:disabled="option.disabled && !option.href ? true : undefined"
+			:tabindex="option.disabled ? -1 : 0"
+			@click="handleClick"
+			@keydown.enter.prevent="handleClick"
+			@keydown.space.prevent="handleClick"
+		>
 			<SVGIcon
-				v-if="option.children"
-				class="menu-item__icon"
-				:name="
-					showChildren ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line'
+				v-if="option.icon"
+				class="ep-menu-item__icon"
+				:name="option.icon"
+				aria-hidden="true"
+			/>
+			<span
+				v-if="!(collapsed && depth === 0) || !option.icon"
+				class="ep-menu-item__label"
+				>{{ option.label }}</span
+			>
+			<span class="ep-menu-item__indicators">
+				<SVGIcon
+					v-if="option.children"
+					class="ep-menu-item__chevron"
+					:name="
+						showChildren
+							? 'ri-arrow-up-s-line'
+							: 'ri-arrow-down-s-line'
+					"
+					aria-hidden="true"
+				/>
+				<span
+					v-if="option.active && !option.children"
+					class="ep-menu-item__active-dot"
+					:class="`ep-menu-item__active-dot--${hue}`"
+					aria-hidden="true"
+				/>
+			</span>
+		</component>
+		<Transition name="ep-menu-children">
+			<ul
+				v-if="
+					option.children &&
+					showChildren &&
+					!(collapsed && depth === 0)
 				"
-			></SVGIcon>
-			<SVGIcon
-				v-if="option.active || !option.children"
-				class="menu-item__icon menu-item__status"
-				:class="[
-					`menu-item__icon--${hue}`,
-					{ 'menu-item__icon--hidden': !option.active },
-				]"
-				name="ri-checkbox-blank-circle-fill"
-			></SVGIcon>
-		</div>
-	</div>
-	<Transition name="nested-children">
-		<div v-if="option.children && showChildren" class="children">
-			<div
-				class="children__bar"
-				:class="[
-					`children__bar--${hue}`,
-					{ 'children__bar--hidden': !skeleton },
-				]"
-			></div>
-			<div class="children__items">
+				class="ep-menu-item__children"
+				role="menu"
+			>
 				<MenuItem
-					v-for="child in option.children"
+					v-for="(child, idx) in option.children"
+					:key="idx"
 					:option="child"
+					:hue="hue"
+					:skeleton="skeleton"
+					:depth="depth + 1"
 					@action="$emit('action')"
-				></MenuItem>
-			</div>
-		</div>
-	</Transition>
+				/>
+			</ul>
+		</Transition>
+	</li>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
-import type { PropType } from "vue";
-import type { menu_item, hue, theme } from "../../utilities/types.interface";
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
 import SVGIcon from "../../general/SVGIcon.vue";
+import type { EpHue } from "../../utilities/types/shared";
 
-export default defineComponent({
-	name: "MenuItem",
-	components: {
-		SVGIcon,
-	},
-	props: {
-		option: {
-			type: Object as PropType<menu_item>,
-			required: true,
-		},
-		hue: {
-			type: String as PropType<hue>,
-			default: "information",
-		},
-		theme: {
-			type: String as PropType<theme>,
-			default: "auto",
-		},
-		skeleton: {
-			type: Boolean as PropType<boolean>,
-			default: true,
-		},
-	},
-	emits: ["action"],
-	data() {
-		return {
-			showChildren: false,
-		};
-	},
-	mounted() {
-		this.showChildren = this.option.expanded || false;
-	},
-	methods: {
-		handleClick(): void {
-			if (this.option.children) {
-				this.showChildren = !this.showChildren;
-			}
-			if (this.option.action) {
-				this.option.action();
-				this.$emit("action");
-			}
-		},
-	},
+export interface MenuItemData {
+	label: string;
+	icon?: string;
+	href?: string;
+	hidden?: boolean;
+	disabled?: boolean;
+	active?: boolean;
+	expanded?: boolean;
+	action?: () => void;
+	children?: MenuItemData[];
+}
+
+export interface MenuItemProps {
+	option: MenuItemData;
+	hue?: EpHue;
+	skeleton?: boolean;
+	depth?: number;
+	collapsed?: boolean;
+}
+
+const props = withDefaults(defineProps<MenuItemProps>(), {
+	hue: "information",
+	skeleton: true,
+	depth: 0,
+	collapsed: false,
 });
+
+const emit = defineEmits<{ (e: "action"): void }>();
+
+const showChildren = ref(false);
+
+onMounted(() => {
+	showChildren.value = props.option.expanded || false;
+});
+
+function handleClick() {
+	if (props.option.disabled) return;
+	if (props.option.children) {
+		showChildren.value = !showChildren.value;
+	}
+	if (props.option.action) {
+		props.option.action();
+		emit("action");
+	}
+}
 </script>
 
-<style lang="scss" scoped>
-.menu-item {
+<style scoped>
+.ep-menu-item {
+	list-style: none;
+	width: 100%;
+}
+
+.ep-menu-item__trigger {
+	appearance: none;
+	background: transparent;
+	color: inherit;
+	border: none;
+	font: inherit;
+	width: 100%;
 	display: flex;
-	flex-direction: row;
 	align-items: center;
 	column-gap: 0.5rem;
-	padding: 0.25rem 0.5rem;
-	border-radius: $border-radius-standard;
+	padding: 0.4rem 0.6rem;
+	border-radius: var(--ep-radius-base);
 	cursor: pointer;
-	transition: $transition-standard;
+	transition: var(--ep-transition-base);
+	text-align: left;
+	text-decoration: none;
 	-webkit-tap-highlight-color: transparent;
-
-	&:focus {
-		outline: 1px solid $color-hyperlink;
-	}
-
-	&__label {
-		white-space: nowrap;
-		user-select: none;
-		@include font-light;
-	}
-
-	&__indicators {
-		margin-left: auto;
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		column-gap: 0.25rem;
-	}
-
-	&__icon {
-		@include hue-color-modifiers;
-
-		&--hidden {
-			opacity: 0;
-		}
-	}
-
-	&__status {
-		font-size: 0.75rem;
-	}
-
-	&:hover {
-		background: $color-background-faded;
-	}
 }
 
-.children {
-	display: grid;
-	grid-template-columns: min-content 1fr;
-	padding-left: 0.875rem;
-	column-gap: 0.35rem;
-
-	&__items {
-		display: flex;
-		flex-direction: column;
-		row-gap: 0.25rem;
-	}
-
-	&__bar {
-		border-radius: $border-radius-standard;
-		width: 0.25rem;
-		@include hue-background-modifiers;
-		background: $color-divider;
-		opacity: 0.25;
-
-		&--hidden {
-			opacity: 0;
-		}
-	}
+.ep-menu-item__trigger:hover:not(.ep-menu-item__trigger--disabled) {
+	background: var(--ep-color-background-faded);
 }
 
-.nested-children-enter-active,
-.nested-children-leave-active {
-	transition: $transition-standard;
+.ep-menu-item__trigger:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: 2px;
 }
 
-.nested-children-enter-from {
-	// height: 0;
+.ep-menu-item__trigger--active {
+	background: var(--ep-color-background-faded);
+	font-weight: 600;
+}
+
+.ep-menu-item__trigger--disabled {
+	cursor: not-allowed;
+	opacity: 0.5;
+	pointer-events: none;
+}
+
+.ep-menu-item__trigger--collapsed {
+	justify-content: center;
+}
+
+.ep-menu-item__icon {
+	flex: 0 0 auto;
+	font-size: 1.1em;
+}
+
+.ep-menu-item__label {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.ep-menu-item__indicators {
+	display: inline-flex;
+	align-items: center;
+	column-gap: 0.25rem;
+	margin-left: auto;
+}
+
+.ep-menu-item__chevron {
+	opacity: 0.6;
+}
+
+.ep-menu-item__active-dot {
+	display: inline-block;
+	height: 0.5rem;
+	width: 0.5rem;
+	border-radius: 50%;
+	background: var(--ep-color-information);
+}
+
+.ep-menu-item__active-dot--primary {
+	background: var(--ep-color-primary);
+}
+.ep-menu-item__active-dot--primary-variant {
+	background: var(--ep-color-primary-variant);
+}
+.ep-menu-item__active-dot--secondary {
+	background: var(--ep-color-secondary);
+}
+.ep-menu-item__active-dot--secondary-variant {
+	background: var(--ep-color-secondary-variant);
+}
+.ep-menu-item__active-dot--error {
+	background: var(--ep-color-error);
+}
+.ep-menu-item__active-dot--success {
+	background: var(--ep-color-success);
+}
+.ep-menu-item__active-dot--warning {
+	background: var(--ep-color-warning);
+}
+.ep-menu-item__active-dot--information {
+	background: var(--ep-color-information);
+}
+
+.ep-menu-item__children {
+	list-style: none;
+	margin: 0.25rem 0 0;
+	padding: 0 0 0 0.75rem;
+	border-left: 2px solid var(--ep-color-divider);
+	display: flex;
+	flex-direction: column;
+	row-gap: 0.15rem;
+}
+
+.ep-menu-children-enter-active,
+.ep-menu-children-leave-active {
+	transition: var(--ep-transition-base);
+	overflow: hidden;
+}
+
+.ep-menu-children-enter-from,
+.ep-menu-children-leave-to {
 	opacity: 0;
-	scale: 0;
-	// transform: translateY(-100%);
-	transform: translate(-100%, -100%);
-}
-
-.nested-children-leave-to {
-	// height: 0;
-	opacity: 0;
-	scale: 0;
-	// transform: translateY(-100%);
-	transform: translate(-100%, -100%);
+	transform: translateY(-0.25rem);
 }
 </style>

--- a/packages/ecosphere/src/navigation/NavigationBar.story.vue
+++ b/packages/ecosphere/src/navigation/NavigationBar.story.vue
@@ -1,0 +1,26 @@
+<template>
+	<Story title="Navigation/NavigationBar">
+		<Variant title="Default">
+			<NavigationBar :branding="branding" />
+		</Variant>
+		<Variant title="With end slot">
+			<NavigationBar :branding="branding">
+				<template #end>
+					<button type="button">Sign in</button>
+				</template>
+			</NavigationBar>
+		</Variant>
+		<Variant title="Affix + dark hue">
+			<NavigationBar :branding="branding" affix hue="secondary" />
+		</Variant>
+	</Story>
+</template>
+
+<script setup lang="ts">
+import NavigationBar, { type NavbarBranding } from "./NavigationBar.vue";
+
+const branding: NavbarBranding = {
+	label: "Ecosphere",
+	action: () => console.log("brand"),
+};
+</script>

--- a/packages/ecosphere/src/navigation/NavigationBar.vue
+++ b/packages/ecosphere/src/navigation/NavigationBar.vue
@@ -1,98 +1,218 @@
 <template>
-	<div class="navbar">
-		<img
-			v-if="branding.logo"
-			class="navbar__logo"
-			:src="branding.logo"
-			@click="handleBrandingClick"
-		/>
-		<div
-			v-if="branding.label"
-			class="navbar__title"
-			:class="`navbar__title--${hue}`"
-			@click="handleBrandingClick"
-		>
-			{{ branding.label }}
-		</div>
-	</div>
+	<header
+		class="ep-navbar"
+		:class="[
+			`ep-navbar--${size}`,
+			`ep-navbar--${theme}`,
+			{
+				'ep-navbar--affix': affix,
+				'ep-navbar--bordered': bordered,
+			},
+		]"
+		role="banner"
+	>
+		<nav class="ep-navbar__inner" :aria-label="ariaLabel">
+			<div class="ep-navbar__brand">
+				<slot name="brand">
+					<component
+						:is="branding?.action ? 'button' : 'div'"
+						class="ep-navbar__brand-inner"
+						:class="{
+							'ep-navbar__brand-inner--clickable': Boolean(
+								branding?.action
+							),
+						}"
+						:type="branding?.action ? 'button' : undefined"
+						@click="onBrandClick"
+					>
+						<img
+							v-if="branding?.logo"
+							class="ep-navbar__logo"
+							:src="branding.logo"
+							:alt="branding.label ?? 'Logo'"
+						/>
+						<span
+							v-if="branding?.label"
+							class="ep-navbar__title"
+							:class="`ep-navbar__title--${hue}`"
+						>
+							{{ branding.label }}
+						</span>
+					</component>
+				</slot>
+			</div>
+			<div class="ep-navbar__center">
+				<slot />
+			</div>
+			<div class="ep-navbar__end">
+				<slot name="end" />
+			</div>
+		</nav>
+	</header>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
-import type { PropType } from "vue";
-import type {
-	hue,
-	theme,
-	menu_item,
-	navbar_branding,
-} from "../utilities/types.interface";
-import { hue_options, theme_options } from "../utilities/types.interface";
+<script setup lang="ts">
+import { useEpSize } from "../composables/useEpSize";
+import type { EpSize } from "../general/config";
+import type { EpHue } from "../utilities/types/shared";
 
-export default defineComponent({
-	name: "NavigationBar",
-	props: {
-		branding: {
-			type: Object as PropType<navbar_branding>,
-			default: () => {
-				return {
-					logo: "",
-					label: "",
-					action: () => {},
-				};
-			},
-		},
-		options: {
-			type: Array as PropType<menu_item[]>,
-			default: () => [],
-		},
-		hue: {
-			type: String as PropType<hue>,
-			default: "primary",
-			validator(value: hue): boolean {
-				return hue_options.includes(value);
-			},
-		},
-		theme: {
-			type: String as PropType<theme>,
-			default: "auto",
-			validator(value: theme): boolean {
-				return theme_options.includes(value);
-			},
-		},
-	},
-	methods: {
-		handleBrandingClick(): void {
-			if (this.branding.action) {
-				this.branding.action();
-			}
-		},
-	},
+export interface NavbarBranding {
+	label?: string;
+	logo?: string;
+	action?: () => void;
+}
+
+export interface NavbarProps {
+	branding?: NavbarBranding;
+	hue?: EpHue;
+	size?: EpSize;
+	theme?: "auto" | "light" | "dark";
+	affix?: boolean;
+	bordered?: boolean;
+	ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<NavbarProps>(), {
+	branding: () => ({}),
+	hue: "primary",
+	size: undefined,
+	theme: "auto",
+	affix: false,
+	bordered: true,
+	ariaLabel: "Primary",
 });
+
+const size = useEpSize(() => props.size);
+
+function onBrandClick() {
+	props.branding?.action?.();
+}
 </script>
 
-<style lang="scss" scoped>
-.navbar {
-	background: $color-background;
-	padding: 0.3rem 0.5rem;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	column-gap: 0.25rem;
-	user-select: none;
+<style scoped>
+.ep-navbar {
+	background: var(--ep-color-background);
+	color: var(--ep-color-contrast);
+	font-family: var(--ep-font-family-base);
 	width: 100%;
+	user-select: none;
+}
 
-	&__logo {
-		max-height: 2rem;
-		cursor: pointer;
-	}
+.ep-navbar--affix {
+	position: sticky;
+	top: 0;
+	z-index: 100;
+}
 
-	&__title {
-		cursor: pointer;
-		transition: $transition-standard;
+.ep-navbar--bordered {
+	border-bottom: 1px solid var(--ep-color-divider);
+}
 
-		&:hover {
-			color: $color-information;
-		}
-	}
+.ep-navbar--xs {
+	font-size: 0.75rem;
+}
+.ep-navbar--sm {
+	font-size: 0.875rem;
+}
+.ep-navbar--md {
+	font-size: 1rem;
+}
+.ep-navbar--lg {
+	font-size: 1.125rem;
+}
+.ep-navbar--xl {
+	font-size: 1.25rem;
+}
+
+.ep-navbar__inner {
+	display: flex;
+	align-items: center;
+	column-gap: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	max-width: 100%;
+}
+
+.ep-navbar__brand {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+}
+
+.ep-navbar__brand-inner {
+	appearance: none;
+	background: none;
+	border: none;
+	color: inherit;
+	font: inherit;
+	padding: 0.25rem 0.25rem;
+	display: inline-flex;
+	align-items: center;
+	column-gap: 0.5rem;
+	border-radius: var(--ep-radius-base);
+	cursor: default;
+}
+
+.ep-navbar__brand-inner--clickable {
+	cursor: pointer;
+	transition: var(--ep-transition-base);
+}
+
+.ep-navbar__brand-inner--clickable:hover {
+	background: var(--ep-color-background-faded);
+}
+
+.ep-navbar__brand-inner--clickable:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: 2px;
+}
+
+.ep-navbar__logo {
+	max-height: 2rem;
+	display: block;
+}
+
+.ep-navbar__title {
+	font-weight: 600;
+	white-space: nowrap;
+	transition: var(--ep-transition-base);
+}
+
+.ep-navbar__title--primary {
+	color: var(--ep-color-primary);
+}
+.ep-navbar__title--primary-variant {
+	color: var(--ep-color-primary-variant);
+}
+.ep-navbar__title--secondary {
+	color: var(--ep-color-secondary);
+}
+.ep-navbar__title--secondary-variant {
+	color: var(--ep-color-secondary-variant);
+}
+.ep-navbar__title--error {
+	color: var(--ep-color-error);
+}
+.ep-navbar__title--success {
+	color: var(--ep-color-success);
+}
+.ep-navbar__title--warning {
+	color: var(--ep-color-warning);
+}
+.ep-navbar__title--information {
+	color: var(--ep-color-information);
+}
+
+.ep-navbar__center {
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	column-gap: 0.5rem;
+}
+
+.ep-navbar__end {
+	display: flex;
+	align-items: center;
+	column-gap: 0.5rem;
 }
 </style>

--- a/packages/ecosphere/src/navigation/SidebarNavigation.story.vue
+++ b/packages/ecosphere/src/navigation/SidebarNavigation.story.vue
@@ -1,0 +1,31 @@
+<template>
+	<Story title="Navigation/SidebarNavigation">
+		<Variant title="Default">
+			<SidebarNavigation :options="options" />
+		</Variant>
+		<Variant title="Collapsible">
+			<SidebarNavigation :options="options" collapsible />
+		</Variant>
+		<Variant title="With header + footer">
+			<SidebarNavigation :options="options" collapsible>
+				<template #header>
+					<strong>Workspace</strong>
+				</template>
+				<template #footer>
+					<small>v1.0.0</small>
+				</template>
+			</SidebarNavigation>
+		</Variant>
+	</Story>
+</template>
+
+<script setup lang="ts">
+import SidebarNavigation from "./SidebarNavigation.vue";
+import type { MenuItemData } from "./MenuNavigation/MenuItem.vue";
+
+const options: MenuItemData[] = [
+	{ label: "Home", icon: "ri-home-line", active: true },
+	{ label: "Dashboard", icon: "ri-dashboard-line" },
+	{ label: "Settings", icon: "ri-settings-line" },
+];
+</script>

--- a/packages/ecosphere/src/navigation/SidebarNavigation.vue
+++ b/packages/ecosphere/src/navigation/SidebarNavigation.vue
@@ -1,199 +1,313 @@
 <template>
-	<div class="sidebar" :class="[{ 'sidebar--responsive': responsive }]">
-		<MenuItem
-			v-for="option in options"
-			:option="option"
-			:hue="hue"
-			:skeleton="skeleton"
-		></MenuItem>
-	</div>
-	<Teleport to="body">
-		<Transition name="sidebar-overlay">
+	<aside
+		class="ep-sidebar"
+		:class="[
+			`ep-sidebar--${size}`,
+			{
+				'ep-sidebar--responsive': responsive,
+				'ep-sidebar--collapsed': effectiveCollapsed,
+			},
+		]"
+		:aria-label="ariaLabel"
+	>
+		<div v-if="$slots.header" class="ep-sidebar__header">
+			<slot name="header" :collapsed="effectiveCollapsed" />
+		</div>
+		<ul class="ep-sidebar__menu" role="menu">
+			<MenuItem
+				v-for="(option, idx) in options"
+				:key="idx"
+				:option="option"
+				:hue="hue"
+				:skeleton="skeleton"
+				:collapsed="effectiveCollapsed"
+			/>
+		</ul>
+		<div v-if="$slots.footer" class="ep-sidebar__footer">
+			<slot name="footer" :collapsed="effectiveCollapsed" />
+		</div>
+		<button
+			v-if="collapsible && !mobileDrawerOpen"
+			type="button"
+			class="ep-sidebar__toggle"
+			:aria-label="
+				effectiveCollapsed ? 'Expand sidebar' : 'Collapse sidebar'
+			"
+			:aria-expanded="!effectiveCollapsed"
+			@click="toggleCollapse"
+		>
+			<SVGIcon
+				:name="
+					effectiveCollapsed
+						? 'ri-arrow-right-s-line'
+						: 'ri-arrow-left-s-line'
+				"
+			/>
+		</button>
+	</aside>
+	<Teleport v-if="responsive" to="body">
+		<Transition name="ep-sidebar-overlay">
 			<div
-				v-if="overlay && responsive"
-				class="overlay"
-				@click="overlay = false"
+				v-if="mobileDrawerOpen"
+				class="ep-sidebar-overlay"
+				@click="mobileDrawerOpen = false"
 			>
-				<div class="overlay__menu" @click.stop>
-					<MenuItem
-						v-for="option in options"
-						:option="option"
-						:hue="hue"
-						:skeleton="skeleton"
-						@action="overlay = false"
-					></MenuItem>
+				<div
+					class="ep-sidebar-overlay__drawer"
+					role="dialog"
+					aria-modal="true"
+					:aria-label="ariaLabel"
+					@click.stop
+				>
+					<div v-if="$slots.header" class="ep-sidebar__header">
+						<slot name="header" :collapsed="false" />
+					</div>
+					<ul class="ep-sidebar__menu" role="menu">
+						<MenuItem
+							v-for="(option, idx) in options"
+							:key="idx"
+							:option="option"
+							:hue="hue"
+							:skeleton="skeleton"
+							@action="mobileDrawerOpen = false"
+						/>
+					</ul>
+					<div v-if="$slots.footer" class="ep-sidebar__footer">
+						<slot name="footer" :collapsed="false" />
+					</div>
 				</div>
 			</div>
 		</Transition>
 	</Teleport>
-	<Teleport to="body">
-		<Transition name="trigger-overlay">
-			<SVGIcon
-				v-if="!overlay && responsive"
-				class="trigger"
-				name="ri-menu-4-line"
-				@click="overlay = true"
-			></SVGIcon>
+	<Teleport v-if="responsive" to="body">
+		<Transition name="ep-sidebar-trigger">
+			<button
+				v-if="!mobileDrawerOpen"
+				type="button"
+				class="ep-sidebar__trigger"
+				aria-label="Open sidebar"
+				@click="mobileDrawerOpen = true"
+			>
+				<SVGIcon name="ri-menu-4-line" />
+			</button>
 		</Transition>
 	</Teleport>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
-import type { PropType } from "vue";
-import type { hue, theme, menu_item } from "../utilities/types.interface";
-import { hue_options, theme_options } from "../utilities/types.interface";
-import MenuItem from "./MenuNavigation/MenuItem.vue";
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
 import SVGIcon from "../general/SVGIcon.vue";
+import MenuItem, { type MenuItemData } from "./MenuNavigation/MenuItem.vue";
+import { useEpSize } from "../composables/useEpSize";
+import type { EpSize } from "../general/config";
+import type { EpHue } from "../utilities/types/shared";
 
-export default defineComponent({
-	name: "SidebarNavigation",
-	components: {
-		SVGIcon,
-		MenuItem,
-	},
-	props: {
-		options: {
-			type: Array as PropType<menu_item[]>,
-			required: true,
-		},
-		hue: {
-			type: String as PropType<hue>,
-			default: "information",
-			validator(value: hue): boolean {
-				return hue_options.includes(value);
-			},
-		},
-		theme: {
-			type: String as PropType<theme>,
-			default: "auto",
-			validator(value: theme): boolean {
-				return theme_options.includes(value);
-			},
-		},
-		skeleton: {
-			type: Boolean as PropType<boolean>,
-			default: true,
-		},
-		responsive: {
-			type: Boolean as PropType<boolean>,
-			default: false,
-		},
-	},
-	data() {
-		return {
-			overlay: false,
-		};
-	},
+export interface SidebarProps {
+	options: MenuItemData[];
+	hue?: EpHue;
+	size?: EpSize;
+	theme?: "auto" | "light" | "dark";
+	skeleton?: boolean;
+	responsive?: boolean;
+	collapsible?: boolean;
+	collapsed?: boolean;
+	ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<SidebarProps>(), {
+	hue: "information",
+	size: undefined,
+	theme: "auto",
+	skeleton: true,
+	responsive: false,
+	collapsible: false,
+	collapsed: false,
+	ariaLabel: "Sidebar",
 });
+
+const emit = defineEmits<{
+	(e: "update:collapsed", value: boolean): void;
+}>();
+
+const size = useEpSize(() => props.size);
+const internalCollapsed = ref(props.collapsed);
+const mobileDrawerOpen = ref(false);
+
+watch(
+	() => props.collapsed,
+	(v) => {
+		internalCollapsed.value = v;
+	}
+);
+
+const effectiveCollapsed = computed(() => internalCollapsed.value);
+
+function toggleCollapse() {
+	internalCollapsed.value = !internalCollapsed.value;
+	emit("update:collapsed", internalCollapsed.value);
+}
 </script>
 
-<style lang="scss" scoped>
-.sidebar {
+<style scoped>
+.ep-sidebar {
+	position: relative;
 	max-height: 100%;
 	overflow-y: auto;
-	background: $color-background;
-	color: $color-contrast;
+	background: var(--ep-color-background);
+	color: var(--ep-color-contrast);
+	font-family: var(--ep-font-family-base);
 	display: flex;
 	flex-direction: column;
-	row-gap: 0.25rem;
 	padding: 0.5rem;
-	transition: $transition-standard;
-	// @include scrollbar-vertical;
+	row-gap: 0.5rem;
+	transition: var(--ep-transition-base);
+	width: 16rem;
+	min-width: 16rem;
+}
 
-	&--responsive {
-		@include respond-below(sm) {
-			display: none;
-		}
+.ep-sidebar--collapsed {
+	width: 3.5rem;
+	min-width: 3.5rem;
+}
+
+.ep-sidebar--responsive {
+	display: flex;
+}
+
+@media (max-width: 640px) {
+	.ep-sidebar--responsive {
+		display: none;
 	}
 }
 
-.overlay {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100vw;
-	height: 100vh;
-	background: rgba(#bbbbbb, 0.8);
-	overflow: hidden;
-	cursor: pointer;
-	display: none;
-	-webkit-tap-highlight-color: transparent;
+.ep-sidebar--xs {
+	font-size: 0.75rem;
+}
+.ep-sidebar--sm {
+	font-size: 0.875rem;
+}
+.ep-sidebar--md {
+	font-size: 1rem;
+}
+.ep-sidebar--lg {
+	font-size: 1.125rem;
+}
+.ep-sidebar--xl {
+	font-size: 1.25rem;
+}
 
-	@include respond-below(sm) {
+.ep-sidebar__menu {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	row-gap: 0.15rem;
+	flex: 1 1 auto;
+}
+
+.ep-sidebar__header,
+.ep-sidebar__footer {
+	padding: 0.25rem;
+}
+
+.ep-sidebar__toggle {
+	appearance: none;
+	background: var(--ep-color-background);
+	color: inherit;
+	border: 1px solid var(--ep-color-divider);
+	border-radius: 50%;
+	height: 1.5rem;
+	width: 1.5rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	position: absolute;
+	top: 0.75rem;
+	right: -0.75rem;
+	z-index: 2;
+}
+
+.ep-sidebar__toggle:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: 2px;
+}
+
+.ep-sidebar-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+	display: none;
+	cursor: pointer;
+	z-index: 1000;
+}
+
+@media (max-width: 640px) {
+	.ep-sidebar-overlay {
 		display: block;
 	}
-
-	&__menu {
-		min-width: 50vw;
-		width: fit-content;
-		background: $color-background;
-		height: 100%;
-		overflow-y: auto;
-		padding: 0.5rem;
-		border-top-right-radius: $border-radius-standard;
-		border-bottom-right-radius: $border-radius-standard;
-
-		@include respond-below(xs) {
-			min-width: 75vw;
-		}
-	}
 }
 
-.trigger {
-	position: absolute;
+.ep-sidebar-overlay__drawer {
+	min-width: 50vw;
+	max-width: 80vw;
+	height: 100%;
+	background: var(--ep-color-background);
+	color: var(--ep-color-contrast);
+	overflow-y: auto;
+	padding: 0.5rem;
+	cursor: default;
+	display: flex;
+	flex-direction: column;
+	row-gap: 0.5rem;
+}
+
+.ep-sidebar__trigger {
+	position: fixed;
 	top: 5.5rem;
 	left: 0;
-	background: $color-background;
+	z-index: 999;
+	appearance: none;
+	background: var(--ep-color-background);
+	color: inherit;
+	border: 1px solid var(--ep-color-divider);
 	padding: 0.5rem;
-	border-top-right-radius: $border-radius-standard;
-	border-bottom-right-radius: $border-radius-standard;
+	border-top-right-radius: var(--ep-radius-base);
+	border-bottom-right-radius: var(--ep-radius-base);
 	cursor: pointer;
-	box-shadow: $box-shadow-standard;
 	display: none;
+}
 
-	@include respond-below(sm) {
-		display: block;
-	}
-
-	&:hover {
-		background: $color-background-faded;
+@media (max-width: 640px) {
+	.ep-sidebar__trigger {
+		display: inline-flex;
 	}
 }
 
-.sidebar-overlay-enter-active,
-.sidebar-overlay-leave-active {
-	transition: $transition-standard;
+.ep-sidebar__trigger:hover {
+	background: var(--ep-color-background-faded);
 }
 
-.trigger-overlay-enter-active,
-.trigger-overlay-leave-active {
-	transition: $transition-standard;
+.ep-sidebar__trigger:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: 2px;
 }
 
-.sidebar-overlay-enter-active .overlay__menu,
-.sidebar-overlay-leave-active .overlay__menu {
-	transition: $transition-standard;
+.ep-sidebar-overlay-enter-active,
+.ep-sidebar-overlay-leave-active,
+.ep-sidebar-trigger-enter-active,
+.ep-sidebar-trigger-leave-active {
+	transition: var(--ep-transition-base);
 }
 
-.sidebar-overlay-enter-from {
+.ep-sidebar-overlay-enter-from,
+.ep-sidebar-overlay-leave-to {
 	opacity: 0;
 }
 
-.sidebar-overlay-leave-to {
-	opacity: 0;
-}
-
-.trigger-overlay-enter-from {
-	transform: translateX(-100%);
-}
-
-.trigger-overlay-leave-to {
-	transform: translateX(-100%);
-}
-
-.sidebar-overlay-enter-from .overlay__menu,
-.sidebar-overlay-leave-to .overlay__menu {
+.ep-sidebar-trigger-enter-from,
+.ep-sidebar-trigger-leave-to {
 	transform: translateX(-100%);
 }
 </style>

--- a/packages/ecosphere/src/navigation/TabNavigation.story.vue
+++ b/packages/ecosphere/src/navigation/TabNavigation.story.vue
@@ -1,0 +1,41 @@
+<template>
+	<Story title="Navigation/TabNavigation">
+		<Variant title="Default (underline)">
+			<TabNavigation v-model:value="value" :options="options">
+				<template #default="{ option }">
+					<div>Content for {{ option.label }}</div>
+				</template>
+			</TabNavigation>
+		</Variant>
+		<Variant title="Vertical">
+			<TabNavigation v-model:value="value" :options="options" vertical />
+		</Variant>
+		<Variant title="Pills">
+			<TabNavigation
+				v-model:value="value"
+				:options="options"
+				variant="pills"
+			/>
+		</Variant>
+		<Variant title="Closable + Addable">
+			<TabNavigation
+				v-model:value="value"
+				:options="options"
+				closable
+				addable
+			/>
+		</Variant>
+	</Story>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import TabNavigation, { type TabOption } from "./TabNavigation.vue";
+
+const options: TabOption[] = [
+	{ label: "Home", icon: "ri-home-line", value: "home" },
+	{ label: "Dashboard", icon: "ri-dashboard-line", value: "dash" },
+	{ label: "Settings", icon: "ri-settings-line", value: "settings" },
+];
+const value = ref<string>("home");
+</script>

--- a/packages/ecosphere/src/navigation/TabNavigation.vue
+++ b/packages/ecosphere/src/navigation/TabNavigation.vue
@@ -1,231 +1,460 @@
 <template>
-	<div class="tabs__wrapper">
-		<div class="tabs" :class="[{ 'tabs--disabled': disabled }]">
-			<div
-				v-for="(option, index) in options"
-				class="tabs__option"
+	<div
+		class="ep-tabs"
+		:class="[
+			`ep-tabs--${size}`,
+			`ep-tabs--${variant}`,
+			{
+				'ep-tabs--vertical': vertical,
+				'ep-tabs--disabled': disabled,
+			},
+		]"
+	>
+		<div
+			ref="tablistRef"
+			class="ep-tabs__list"
+			role="tablist"
+			:aria-label="ariaLabel"
+			:aria-orientation="vertical ? 'vertical' : 'horizontal'"
+		>
+			<button
+				v-for="(option, index) in visibleOptions"
+				:id="`${tablistId}-tab-${index}`"
+				:key="String(option.value)"
+				ref="tabRefs"
+				type="button"
+				role="tab"
+				class="ep-tabs__tab"
 				:class="[
 					{
-						'tabs__option--disabled': option.disabled,
-						'tabs__option--vertical': iconPosition === 'above',
+						'ep-tabs__tab--selected': isSelected(option),
+						'ep-tabs__tab--disabled': option.disabled,
+						'ep-tabs__tab--icon-above': iconPosition === 'above',
 					},
-					value === index ? `tabs__option--${hue}` : '',
+					isSelected(option) ? `ep-tabs__tab--${hue}` : '',
 				]"
-				:tabindex="option.disabled || disabled ? -1 : 0"
-				@click="handleClick(index)"
-				@keypress.enter="handleClick(index)"
+				:aria-selected="isSelected(option) ? 'true' : 'false'"
+				:aria-controls="option.panelId ?? `${tablistId}-panel-${index}`"
+				:aria-disabled="option.disabled ? 'true' : undefined"
+				:tabindex="isSelected(option) ? 0 : -1"
+				:disabled="disabled || option.disabled"
+				@click="select(option)"
+				@keydown="onKeydown($event, index)"
 			>
 				<SVGIcon
 					v-if="
-						(iconPosition === 'before' ||
-							iconPosition === 'above') &&
-						option.icon
+						option.icon &&
+						(iconPosition === 'before' || iconPosition === 'above')
 					"
-					class="tabs__option-icon"
-					:class="[
-						{
-							'tabs__option-icon--above':
-								iconPosition === 'above',
-						},
-					]"
+					class="ep-tabs__icon"
+					:class="{
+						'ep-tabs__icon--above': iconPosition === 'above',
+					}"
 					:name="option.icon"
-				></SVGIcon>
-				<div class="tabs__option-label">{{ option.label }}</div>
+					aria-hidden="true"
+				/>
+				<span v-if="option.label" class="ep-tabs__label">{{
+					option.label
+				}}</span>
 				<SVGIcon
-					v-if="iconPosition === 'after' && option.icon"
-					class="tabs__option-icon"
+					v-if="option.icon && iconPosition === 'after'"
+					class="ep-tabs__icon"
 					:name="option.icon"
-				></SVGIcon>
+					aria-hidden="true"
+				/>
+				<button
+					v-if="closable && !option.disabled"
+					type="button"
+					class="ep-tabs__close"
+					:aria-label="`Close ${option.label ?? 'tab'}`"
+					@click.stop="close(option, index)"
+				>
+					<SVGIcon name="ri-close-line" />
+				</button>
+			</button>
+			<button
+				v-if="addable"
+				type="button"
+				class="ep-tabs__add"
+				aria-label="Add tab"
+				@click="emit('add')"
+			>
+				<SVGIcon name="ri-add-line" />
+			</button>
+			<div v-if="$slots.extra" class="ep-tabs__extra">
+				<slot name="extra" />
+			</div>
+		</div>
+		<div class="ep-tabs__panels">
+			<div
+				v-for="(option, index) in visibleOptions"
+				:id="option.panelId ?? `${tablistId}-panel-${index}`"
+				:key="`panel-${String(option.value)}`"
+				class="ep-tabs__panel"
+				role="tabpanel"
+				:aria-labelledby="`${tablistId}-tab-${index}`"
+				:hidden="!isSelected(option)"
+				tabindex="0"
+			>
+				<slot
+					v-if="isSelected(option) || !lazy"
+					:name="`tab-${String(option.value)}`"
+					:option="option"
+				>
+					<slot name="default" :option="option" />
+				</slot>
 			</div>
 		</div>
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent, type PropType } from "vue";
-import {
-	tab_navigation_option_icon_position_options,
-	hue_options,
-} from "../utilities/types.interface";
-import type {
-	tab_navigation_option,
-	tab_navigation_option_icon_position,
-	hue,
-} from "../utilities/types.interface";
+<script setup lang="ts">
+import { computed, nextTick, ref } from "vue";
 import SVGIcon from "../general/SVGIcon.vue";
+import { useEpSize } from "../composables/useEpSize";
+import { useEpId } from "../composables/useEpId";
+import type { EpSize } from "../general/config";
+import type { EpHue } from "../utilities/types/shared";
 
-export default defineComponent({
-	name: "TabNavigation",
-	components: {
-		SVGIcon,
-	},
-	props: {
-		options: {
-			type: Array as PropType<tab_navigation_option[]>,
-			required: true,
-		},
-		disabled: {
-			type: Boolean as PropType<boolean>,
-			default: false,
-		},
-		iconPosition: {
-			type: String as PropType<tab_navigation_option_icon_position>,
-			default: "before",
-			validator(value: tab_navigation_option_icon_position): boolean {
-				return tab_navigation_option_icon_position_options.includes(
-					value
-				);
-			},
-		},
-		modelValue: {
-			type: [String, Number, Boolean, null] as PropType<
-				string | number | boolean | null
-			>,
-			default: null,
-		},
-		default: {
-			type: [String, Number, Boolean, null] as PropType<
-				string | number | boolean | null
-			>,
-			default: null,
-		},
-		hue: {
-			type: String as PropType<hue>,
-			default: "information",
-			validator(value: hue): boolean {
-				return hue_options.includes(value);
-			},
-		},
-	},
-	data() {
-		return {
-			value: null as null | number | string | boolean,
-		};
-	},
-	watch: {
-		default(newDefault: string | number | boolean | null): void {
-			if (newDefault === null) {
-				this.value = null;
-			} else {
-				this.options.forEach(
-					(option: tab_navigation_option, index: number) => {
-						if (option.value === newDefault) {
-							this.value = index;
-						}
-					}
-				);
-			}
-		},
-		modelValue(newValue: string | number | boolean | null): void {
-			if (newValue === null) {
-				this.value = null;
-			} else {
-				this.options.forEach(
-					(option: tab_navigation_option, index: number) => {
-						if (option.value === newValue) {
-							this.value = index;
-						}
-					}
-				);
-			}
-		},
-	},
-	mounted() {
-		const initialValue =
-			this.default !== null ? this.default : this.modelValue;
-		if (initialValue !== null) {
-			this.options.forEach(
-				(option: tab_navigation_option, index: number) => {
-					if (option.value === initialValue) {
-						this.value = index;
-					}
-				}
-			);
-		}
-	},
-	methods: {
-		handleClick(index: number): void {
-			this.value = index;
-			this.$emit("update:modelValue", this.options[this.value].value);
-			this.$emit("update", this.options[this.value].value);
-			if (this.options[this.value].action) {
-				(this.options[this.value].action as () => void)();
-			}
-		},
-	},
+export type TabIconPosition = "before" | "after" | "above";
+export type TabValue = string | number | boolean | null;
+
+export interface TabOption {
+	label?: string;
+	icon?: string;
+	value: Exclude<TabValue, null>;
+	hidden?: boolean;
+	disabled?: boolean;
+	panelId?: string;
+}
+
+export interface TabsProps {
+	options: TabOption[];
+	value?: TabValue;
+	hue?: EpHue;
+	size?: EpSize;
+	iconPosition?: TabIconPosition;
+	disabled?: boolean;
+	vertical?: boolean;
+	variant?: "underline" | "filled" | "pills";
+	addable?: boolean;
+	closable?: boolean;
+	lazy?: boolean;
+	ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<TabsProps>(), {
+	value: null,
+	hue: "information",
+	size: undefined,
+	iconPosition: "before",
+	disabled: false,
+	vertical: false,
+	variant: "underline",
+	addable: false,
+	closable: false,
+	lazy: true,
+	ariaLabel: "Tabs",
 });
+
+const emit = defineEmits<{
+	(e: "update:value", value: TabValue): void;
+	(e: "change", value: TabValue, option: TabOption): void;
+	(e: "add"): void;
+	(e: "close", option: TabOption, index: number): void;
+}>();
+
+const tablistId = useEpId("ep-tabs");
+const size = useEpSize(() => props.size);
+const tabRefs = ref<HTMLButtonElement[]>([]);
+const tablistRef = ref<HTMLDivElement | null>(null);
+
+const visibleOptions = computed(() => props.options.filter((o) => !o.hidden));
+
+function isSelected(option: TabOption) {
+	return props.value === option.value;
+}
+
+function select(option: TabOption) {
+	if (props.disabled || option.disabled) return;
+	if (isSelected(option)) return;
+	emit("update:value", option.value);
+	emit("change", option.value, option);
+}
+
+function close(option: TabOption, index: number) {
+	emit("close", option, index);
+}
+
+function focusTab(index: number) {
+	nextTick(() => {
+		tabRefs.value[index]?.focus();
+	});
+}
+
+function findNextEnabled(start: number, dir: 1 | -1): number {
+	const list = visibleOptions.value;
+	const len = list.length;
+	for (let i = 1; i <= len; i++) {
+		const next = (start + dir * i + len) % len;
+		if (!list[next].disabled) return next;
+	}
+	return start;
+}
+
+function onKeydown(e: KeyboardEvent, index: number) {
+	const horiz = !props.vertical;
+	const nextKey = horiz ? "ArrowRight" : "ArrowDown";
+	const prevKey = horiz ? "ArrowLeft" : "ArrowUp";
+	if (e.key === nextKey) {
+		e.preventDefault();
+		const next = findNextEnabled(index, 1);
+		focusTab(next);
+		select(visibleOptions.value[next]);
+	} else if (e.key === prevKey) {
+		e.preventDefault();
+		const next = findNextEnabled(index, -1);
+		focusTab(next);
+		select(visibleOptions.value[next]);
+	} else if (e.key === "Home") {
+		e.preventDefault();
+		const next = findNextEnabled(-1, 1);
+		focusTab(next);
+		select(visibleOptions.value[next]);
+	} else if (e.key === "End") {
+		e.preventDefault();
+		const next = findNextEnabled(visibleOptions.value.length, -1);
+		focusTab(next);
+		select(visibleOptions.value[next]);
+	}
+}
 </script>
 
-<style lang="scss" scoped>
-.tabs {
-	display: grid;
-	grid-auto-flow: column;
-	grid-auto-columns: 1fr;
-	column-gap: 1px;
-	border-radius: $border-radius-standard;
-	overflow: hidden;
-	width: fit-content;
-	background: $color-background-faded;
+<style scoped>
+.ep-tabs {
+	display: flex;
+	flex-direction: column;
+	font-family: var(--ep-font-family-base);
+	color: var(--ep-color-contrast);
+}
 
-	&__wrapper {
-		overflow-x: auto;
-		padding-bottom: 0.5rem;
-	}
+.ep-tabs--vertical {
+	flex-direction: row;
+	column-gap: 0.5rem;
+}
 
-	&--disabled {
-		opacity: 50%;
-		pointer-events: none;
-	}
+.ep-tabs--disabled {
+	opacity: 0.5;
+	pointer-events: none;
+}
 
-	&__option {
-		background: $color-background;
-		padding: 0.55rem 1rem 0.5rem;
-		display: flex;
-		align-items: center;
-		column-gap: 0.5rem;
-		cursor: pointer;
-		border-bottom: 2px solid transparent;
-		@include hue-border-modifiers(border-bottom, 2px);
-		@include hue-color-modifiers;
-		user-select: none;
-		transition: $transition-standard;
-		-webkit-tap-highlight-color: transparent;
-		justify-content: center;
+.ep-tabs--xs {
+	font-size: 0.75rem;
+}
+.ep-tabs--sm {
+	font-size: 0.875rem;
+}
+.ep-tabs--md {
+	font-size: 1rem;
+}
+.ep-tabs--lg {
+	font-size: 1.125rem;
+}
+.ep-tabs--xl {
+	font-size: 1.25rem;
+}
 
-		&:focus {
-			background: $color-background-faded;
-			outline: none;
-			// color: $color-information;
-			// border-radius: $border-radius-standard;
-			// border: 1px solid $color-information;
-		}
+.ep-tabs__list {
+	display: flex;
+	flex-direction: row;
+	align-items: stretch;
+	flex-wrap: nowrap;
+	border-bottom: 1px solid var(--ep-color-divider);
+	overflow-x: auto;
+}
 
-		&:hover {
-			background: $color-background-faded;
-			// color: $color-information;
-		}
+.ep-tabs--vertical .ep-tabs__list {
+	flex-direction: column;
+	border-bottom: none;
+	border-right: 1px solid var(--ep-color-divider);
+	overflow-x: visible;
+}
 
-		&--disabled {
-			opacity: 30%;
-			pointer-events: none;
-		}
+.ep-tabs--pills .ep-tabs__list,
+.ep-tabs--filled .ep-tabs__list {
+	border: none;
+	column-gap: 0.25rem;
+}
 
-		&--vertical {
-			flex-direction: column;
-			row-gap: 0.25rem;
-			justify-content: flex-end;
-		}
-	}
+.ep-tabs__tab {
+	appearance: none;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	border: none;
+	border-bottom: 2px solid transparent;
+	padding: 0.55rem 1rem 0.5rem;
+	display: inline-flex;
+	align-items: center;
+	column-gap: 0.5rem;
+	cursor: pointer;
+	transition: var(--ep-transition-base);
+	-webkit-tap-highlight-color: transparent;
+	user-select: none;
+	white-space: nowrap;
+	justify-content: center;
+}
 
-	&__option-label {
-		display: block;
-		white-space: nowrap;
-	}
+.ep-tabs--vertical .ep-tabs__tab {
+	border-bottom: none;
+	border-right: 2px solid transparent;
+	justify-content: flex-start;
+}
 
-	&__option-icon {
-		&--above {
-			font-size: 1.25rem;
-		}
-	}
+.ep-tabs__tab:hover:not(.ep-tabs__tab--disabled):not(.ep-tabs__tab--selected) {
+	background: var(--ep-color-background-faded);
+}
+
+.ep-tabs__tab:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: -2px;
+}
+
+.ep-tabs__tab--disabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+}
+
+.ep-tabs__tab--icon-above {
+	flex-direction: column;
+	row-gap: 0.25rem;
+}
+
+.ep-tabs--pills .ep-tabs__tab {
+	border: none;
+	border-radius: var(--ep-radius-pill, 999px);
+}
+.ep-tabs--filled .ep-tabs__tab {
+	border: none;
+	border-radius: var(--ep-radius-base);
+}
+
+/* selected color per hue (underline + pill/filled bg) */
+.ep-tabs__tab--selected.ep-tabs__tab--primary {
+	border-color: var(--ep-color-primary);
+	color: var(--ep-color-primary);
+}
+.ep-tabs__tab--selected.ep-tabs__tab--primary-variant {
+	border-color: var(--ep-color-primary-variant);
+	color: var(--ep-color-primary-variant);
+}
+.ep-tabs__tab--selected.ep-tabs__tab--secondary {
+	border-color: var(--ep-color-secondary);
+	color: var(--ep-color-secondary);
+}
+.ep-tabs__tab--selected.ep-tabs__tab--secondary-variant {
+	border-color: var(--ep-color-secondary-variant);
+	color: var(--ep-color-secondary-variant);
+}
+.ep-tabs__tab--selected.ep-tabs__tab--error {
+	border-color: var(--ep-color-error);
+	color: var(--ep-color-error);
+}
+.ep-tabs__tab--selected.ep-tabs__tab--success {
+	border-color: var(--ep-color-success);
+	color: var(--ep-color-success);
+}
+.ep-tabs__tab--selected.ep-tabs__tab--warning {
+	border-color: var(--ep-color-warning);
+	color: var(--ep-color-warning);
+}
+.ep-tabs__tab--selected.ep-tabs__tab--information {
+	border-color: var(--ep-color-information);
+	color: var(--ep-color-information);
+}
+
+.ep-tabs--pills .ep-tabs__tab--selected,
+.ep-tabs--filled .ep-tabs__tab--selected {
+	color: var(--ep-color-contrast);
+}
+.ep-tabs--pills .ep-tabs__tab--selected.ep-tabs__tab--primary,
+.ep-tabs--filled .ep-tabs__tab--selected.ep-tabs__tab--primary {
+	background: var(--ep-color-primary);
+	color: var(--ep-color-primary-contrast);
+}
+.ep-tabs--pills .ep-tabs__tab--selected.ep-tabs__tab--secondary,
+.ep-tabs--filled .ep-tabs__tab--selected.ep-tabs__tab--secondary {
+	background: var(--ep-color-secondary);
+	color: var(--ep-color-secondary-contrast);
+}
+.ep-tabs--pills .ep-tabs__tab--selected.ep-tabs__tab--information,
+.ep-tabs--filled .ep-tabs__tab--selected.ep-tabs__tab--information {
+	background: var(--ep-color-information);
+	color: var(--ep-color-contrast);
+}
+
+.ep-tabs__icon--above {
+	font-size: 1.25em;
+}
+
+.ep-tabs__close {
+	appearance: none;
+	background: transparent;
+	color: inherit;
+	border: none;
+	padding: 0;
+	margin-left: 0.25rem;
+	cursor: pointer;
+	border-radius: var(--ep-radius-base);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.ep-tabs__close:hover {
+	background: var(--ep-color-background-faded);
+}
+
+.ep-tabs__add {
+	appearance: none;
+	background: transparent;
+	color: inherit;
+	border: none;
+	padding: 0.5rem 0.75rem;
+	cursor: pointer;
+	border-radius: var(--ep-radius-base);
+	display: inline-flex;
+	align-items: center;
+}
+
+.ep-tabs__add:hover {
+	background: var(--ep-color-background-faded);
+}
+
+.ep-tabs__add:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: -2px;
+}
+
+.ep-tabs__extra {
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	column-gap: 0.5rem;
+	padding: 0 0.5rem;
+}
+
+.ep-tabs__panels {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.ep-tabs__panel {
+	padding: 0.75rem 0;
+}
+
+.ep-tabs__panel:focus-visible {
+	outline: var(--ep-outline-focus);
+	outline-offset: 2px;
 }
 </style>

--- a/packages/ecosphere/src/navigation/__tests__/BreadcrumbNavigation.spec.ts
+++ b/packages/ecosphere/src/navigation/__tests__/BreadcrumbNavigation.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import BreadcrumbNavigation, {
+	type BreadcrumbItem,
+} from "../BreadcrumbNavigation.vue";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+const items: BreadcrumbItem[] = [
+	{ label: "Home", href: "/" },
+	{ label: "Library", href: "/library" },
+	{ label: "Data", active: true },
+];
+
+describe("EpBreadcrumb", () => {
+	it("renders nav with aria-label and ordered list", () => {
+		const w = mount(BreadcrumbNavigation, { props: { items } });
+		expect(w.find("nav").attributes("aria-label")).toBe("Breadcrumb");
+		expect(w.find("ol").exists()).toBe(true);
+	});
+
+	it("marks active item with aria-current=page", () => {
+		const w = mount(BreadcrumbNavigation, { props: { items } });
+		const current = w.find('[aria-current="page"]');
+		expect(current.exists()).toBe(true);
+		expect(current.text()).toContain("Data");
+	});
+
+	it("renders separators between items", () => {
+		const w = mount(BreadcrumbNavigation, { props: { items } });
+		expect(w.findAll(".ep-breadcrumb__separator").length).toBe(
+			items.length - 1
+		);
+	});
+
+	it("filters hidden items", () => {
+		const w = mount(BreadcrumbNavigation, {
+			props: {
+				items: [...items, { label: "Hidden", hidden: true }],
+			},
+		});
+		expect(w.findAll(".ep-breadcrumb__item").length).toBe(items.length);
+	});
+
+	it("emits select on click of non-active item", async () => {
+		const w = mount(BreadcrumbNavigation, { props: { items } });
+		await w.find(".ep-breadcrumb__link").trigger("click");
+		expect(w.emitted("select")).toBeTruthy();
+	});
+
+	it("disabled item is non-interactive", async () => {
+		const w = mount(BreadcrumbNavigation, {
+			props: {
+				items: [
+					{ label: "X", disabled: true },
+					{ label: "Y", active: true },
+				],
+			},
+		});
+		const link = w.find(".ep-breadcrumb__item--disabled span");
+		expect(link.exists()).toBe(true);
+	});
+
+	it("has no axe violations", async () => {
+		const w = mount(BreadcrumbNavigation, {
+			props: { items },
+			attachTo: document.body,
+		});
+		await expectNoA11yViolations(w.element as HTMLElement);
+		w.unmount();
+	});
+});

--- a/packages/ecosphere/src/navigation/__tests__/MenuNavigation.spec.ts
+++ b/packages/ecosphere/src/navigation/__tests__/MenuNavigation.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import MenuNavigation, { type MenuItemData } from "../MenuNavigation.vue";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+const options: MenuItemData[] = [
+	{ label: "Home", icon: "ri-home-line", active: true },
+	{
+		label: "Products",
+		icon: "ri-box-3-line",
+		children: [{ label: "Plants" }, { label: "Seeds" }],
+	},
+	{ label: "Disabled", disabled: true },
+];
+
+describe("EpMenu", () => {
+	it("renders ul with role=menu", () => {
+		const w = mount(MenuNavigation, { props: { options } });
+		expect(w.find("ul[role='menu']").exists()).toBe(true);
+	});
+
+	it("renders one item per option (incl. nested unmounted by default)", () => {
+		const w = mount(MenuNavigation, { props: { options } });
+		const items = w.findAll(".ep-menu-item");
+		expect(items.length).toBeGreaterThanOrEqual(options.length);
+	});
+
+	it("active item gets aria-current=page", () => {
+		const w = mount(MenuNavigation, { props: { options } });
+		expect(w.find('[aria-current="page"]').exists()).toBe(true);
+	});
+
+	it("disabled item is aria-disabled", () => {
+		const w = mount(MenuNavigation, { props: { options } });
+		const disabled = w.find('[aria-disabled="true"]');
+		expect(disabled.exists()).toBe(true);
+	});
+
+	it("clicking parent toggles children visibility", async () => {
+		const w = mount(MenuNavigation, { props: { options } });
+		const triggers = w.findAll(".ep-menu-item__trigger");
+		const productsTrigger = triggers.find((t) =>
+			t.text().includes("Products")
+		)!;
+		expect(productsTrigger.attributes("aria-expanded")).toBe("false");
+		await productsTrigger.trigger("click");
+		expect(productsTrigger.attributes("aria-expanded")).toBe("true");
+	});
+
+	it("calls action on activation", async () => {
+		let called = false;
+		const opts: MenuItemData[] = [
+			{ label: "X", action: () => (called = true) },
+		];
+		const w = mount(MenuNavigation, { props: { options: opts } });
+		await w.find(".ep-menu-item__trigger").trigger("click");
+		expect(called).toBe(true);
+	});
+
+	it("has no axe violations", async () => {
+		const w = mount(MenuNavigation, {
+			props: { options },
+			attachTo: document.body,
+		});
+		await expectNoA11yViolations(w.element as HTMLElement);
+		w.unmount();
+	});
+});

--- a/packages/ecosphere/src/navigation/__tests__/NavigationBar.spec.ts
+++ b/packages/ecosphere/src/navigation/__tests__/NavigationBar.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import NavigationBar from "../NavigationBar.vue";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+describe("EpNavbar", () => {
+	it("renders header with banner role", () => {
+		const w = mount(NavigationBar, {
+			props: { branding: { label: "Ecosphere" } },
+		});
+		expect(w.find("[role='banner']").exists()).toBe(true);
+		expect(w.find("nav").attributes("aria-label")).toBe("Primary");
+	});
+
+	it("renders branding label and logo", () => {
+		const w = mount(NavigationBar, {
+			props: {
+				branding: { label: "Ecosphere", logo: "/logo.png" },
+			},
+		});
+		expect(w.text()).toContain("Ecosphere");
+		const img = w.find("img");
+		expect(img.exists()).toBe(true);
+		expect(img.attributes("alt")).toBe("Ecosphere");
+	});
+
+	it("brand is a button when action provided", async () => {
+		let clicked = false;
+		const w = mount(NavigationBar, {
+			props: {
+				branding: { label: "X", action: () => (clicked = true) },
+			},
+		});
+		const btn = w.find(".ep-navbar__brand-inner");
+		expect(btn.element.tagName).toBe("BUTTON");
+		await btn.trigger("click");
+		expect(clicked).toBe(true);
+	});
+
+	it("renders default and end slot content", () => {
+		const w = mount(NavigationBar, {
+			props: { branding: { label: "X" } },
+			slots: {
+				default: "<span class='center'>Center</span>",
+				end: "<button class='cta'>Sign in</button>",
+			},
+		});
+		expect(w.find(".center").exists()).toBe(true);
+		expect(w.find(".cta").exists()).toBe(true);
+	});
+
+	it("affix prop adds sticky modifier class", () => {
+		const w = mount(NavigationBar, {
+			props: { branding: { label: "X" }, affix: true },
+		});
+		expect(w.classes()).toContain("ep-navbar--affix");
+	});
+
+	it("has no axe violations", async () => {
+		const w = mount(NavigationBar, {
+			props: { branding: { label: "Ecosphere", logo: "/logo.png" } },
+			attachTo: document.body,
+		});
+		await expectNoA11yViolations(w.element as HTMLElement);
+		w.unmount();
+	});
+});

--- a/packages/ecosphere/src/navigation/__tests__/SidebarNavigation.spec.ts
+++ b/packages/ecosphere/src/navigation/__tests__/SidebarNavigation.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SidebarNavigation from "../SidebarNavigation.vue";
+import type { MenuItemData } from "../MenuNavigation/MenuItem.vue";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+const options: MenuItemData[] = [
+	{ label: "Home", icon: "ri-home-line", active: true },
+	{ label: "Dashboard", icon: "ri-dashboard-line" },
+];
+
+describe("EpSidebar", () => {
+	it("renders aside with aria-label", () => {
+		const w = mount(SidebarNavigation, { props: { options } });
+		const aside = w.find("aside");
+		expect(aside.exists()).toBe(true);
+		expect(aside.attributes("aria-label")).toBe("Sidebar");
+	});
+
+	it("renders menu items", () => {
+		const w = mount(SidebarNavigation, { props: { options } });
+		expect(w.findAll(".ep-menu-item").length).toBe(options.length);
+	});
+
+	it("collapsible toggle button toggles aria-expanded + emits update:collapsed", async () => {
+		const w = mount(SidebarNavigation, {
+			props: { options, collapsible: true },
+		});
+		const btn = w.find(".ep-sidebar__toggle");
+		expect(btn.exists()).toBe(true);
+		expect(btn.attributes("aria-expanded")).toBe("true");
+		await btn.trigger("click");
+		expect(w.emitted("update:collapsed")?.[0]).toEqual([true]);
+	});
+
+	it("renders header and footer slots", () => {
+		const w = mount(SidebarNavigation, {
+			props: { options },
+			slots: {
+				header: "<div class='h'>H</div>",
+				footer: "<div class='f'>F</div>",
+			},
+		});
+		expect(w.find(".h").exists()).toBe(true);
+		expect(w.find(".f").exists()).toBe(true);
+	});
+
+	it("collapsed class applied when collapsed prop is true", () => {
+		const w = mount(SidebarNavigation, {
+			props: { options, collapsed: true, collapsible: true },
+		});
+		expect(w.find("aside").classes()).toContain("ep-sidebar--collapsed");
+	});
+
+	it("has no axe violations", async () => {
+		const w = mount(SidebarNavigation, {
+			props: { options },
+			attachTo: document.body,
+		});
+		await expectNoA11yViolations(w.element as HTMLElement);
+		w.unmount();
+	});
+});

--- a/packages/ecosphere/src/navigation/__tests__/TabNavigation.spec.ts
+++ b/packages/ecosphere/src/navigation/__tests__/TabNavigation.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import TabNavigation, { type TabOption } from "../TabNavigation.vue";
+import { expectNoA11yViolations } from "../../test/a11y";
+
+const options: TabOption[] = [
+	{ label: "Home", value: "home" },
+	{ label: "Dashboard", value: "dash" },
+	{ label: "Disabled", value: "disabled", disabled: true },
+	{ label: "Settings", value: "settings" },
+];
+
+describe("EpTabNavigation", () => {
+	it("renders tablist + tab + tabpanel roles", () => {
+		const w = mount(TabNavigation, { props: { options, value: "home" } });
+		expect(w.find("[role='tablist']").exists()).toBe(true);
+		expect(w.findAll("[role='tab']").length).toBe(options.length);
+		expect(w.findAll("[role='tabpanel']").length).toBe(options.length);
+	});
+
+	it("marks selected tab with aria-selected=true", () => {
+		const w = mount(TabNavigation, { props: { options, value: "dash" } });
+		const tabs = w.findAll("[role='tab']");
+		expect(tabs[0].attributes("aria-selected")).toBe("false");
+		expect(tabs[1].attributes("aria-selected")).toBe("true");
+	});
+
+	it("emits update:value on click", async () => {
+		const w = mount(TabNavigation, { props: { options, value: "home" } });
+		await w.findAll("[role='tab']")[1].trigger("click");
+		expect(w.emitted("update:value")?.[0]).toEqual(["dash"]);
+		expect(w.emitted("change")?.[0]?.[0]).toBe("dash");
+	});
+
+	it("does not select disabled tab", async () => {
+		const w = mount(TabNavigation, { props: { options, value: "home" } });
+		await w.findAll("[role='tab']")[2].trigger("click");
+		expect(w.emitted("update:value")).toBeFalsy();
+	});
+
+	it("arrow keys move selection, skipping disabled", async () => {
+		const w = mount(TabNavigation, {
+			props: { options, value: "dash" },
+			attachTo: document.body,
+		});
+		const tabs = w.findAll("[role='tab']");
+		await tabs[1].trigger("keydown", { key: "ArrowRight" });
+		expect(w.emitted("update:value")?.[0]).toEqual(["settings"]);
+		w.unmount();
+	});
+
+	it("emits close on closable tab close button", async () => {
+		const w = mount(TabNavigation, {
+			props: { options, value: "home", closable: true },
+		});
+		await w.find(".ep-tabs__close").trigger("click");
+		expect(w.emitted("close")).toBeTruthy();
+	});
+
+	it("emits add on add button", async () => {
+		const w = mount(TabNavigation, {
+			props: { options, value: "home", addable: true },
+		});
+		await w.find(".ep-tabs__add").trigger("click");
+		expect(w.emitted("add")).toBeTruthy();
+	});
+
+	it("has no axe violations", async () => {
+		const w = mount(TabNavigation, {
+			props: { options, value: "home" },
+			attachTo: document.body,
+		});
+		await expectNoA11yViolations(w.element as HTMLElement);
+		w.unmount();
+	});
+});

--- a/packages/ecosphere/src/test/a11y.ts
+++ b/packages/ecosphere/src/test/a11y.ts
@@ -1,4 +1,8 @@
-import axe, { type AxeResults, type RunOptions, type ElementContext } from "axe-core";
+import axe, {
+	type AxeResults,
+	type RunOptions,
+	type ElementContext,
+} from "axe-core";
 import { expect } from "vitest";
 
 /**
@@ -10,13 +14,19 @@ import { expect } from "vitest";
  */
 export async function expectNoA11yViolations(
 	context: ElementContext,
-	options: RunOptions = {},
+	options: RunOptions = {}
 ): Promise<AxeResults> {
 	const results = await axe.run(context, {
 		// Common defaults: run WCAG 2.1 AA + best-practice rules.
 		runOnly: {
 			type: "tag",
-			values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"],
+			values: [
+				"wcag2a",
+				"wcag2aa",
+				"wcag21a",
+				"wcag21aa",
+				"best-practice",
+			],
 		},
 		...options,
 	});
@@ -27,7 +37,7 @@ export async function expectNoA11yViolations(
 				(v) =>
 					`- [${v.id}] ${v.help} (${v.impact})\n  ${v.helpUrl}\n  nodes: ${v.nodes
 						.map((n) => n.target.join(" "))
-						.join(", ")}`,
+						.join(", ")}`
 			)
 			.join("\n");
 		throw new Error(`axe-core a11y violations:\n${formatted}`);

--- a/packages/ecosphere/src/utilities/types/shared.ts
+++ b/packages/ecosphere/src/utilities/types/shared.ts
@@ -3,7 +3,12 @@
 // so consumers can import `EpSize` / `EpStatus` / `EpHue` without pulling the
 // full legacy type surface.
 
-export type EpStatus = "default" | "error" | "warning" | "success" | "information";
+export type EpStatus =
+	| "default"
+	| "error"
+	| "warning"
+	| "success"
+	| "information";
 export const epStatusOptions: EpStatus[] = [
 	"default",
 	"error",

--- a/packages/ecosphere/vite.config.ts
+++ b/packages/ecosphere/vite.config.ts
@@ -19,19 +19,6 @@ export default defineConfig({
 			"@": fileURLToPath(new URL("./src", import.meta.url)),
 		},
 	},
-	css: {
-		preprocessorOptions: {
-			scss: {
-				additionalData: `@import "@/styles/framework.scss";`,
-				api: "modern-compiler",
-				silenceDeprecations: [
-					"legacy-js-api",
-					"import",
-					"global-builtin",
-				],
-			},
-		},
-	},
 	build: {
 		cssCodeSplit: false,
 		sourcemap: true,

--- a/packages/ecosphere/vitest.config.ts
+++ b/packages/ecosphere/vitest.config.ts
@@ -1,7 +1,5 @@
 // Vitest config for vue-ecosphere library tests.
-// Note: production build still uses vite.config.ts (which keeps the SCSS
-// preprocessor pipeline for transitional components). Tests don't compile
-// styles, so this config keeps the surface minimal.
+// Plain-CSS only — no SCSS preprocessing.
 
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vitest/config";
@@ -12,19 +10,6 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": fileURLToPath(new URL("./src", import.meta.url)),
-		},
-	},
-	css: {
-		preprocessorOptions: {
-			scss: {
-				additionalData: `@import "@/styles/framework.scss";`,
-				api: "modern-compiler",
-				silenceDeprecations: [
-					"legacy-js-api",
-					"import",
-					"global-builtin",
-				],
-			},
 		},
 	},
 	test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
-      sass:
-        specifier: ^1.80.6
-        version: 1.99.0
       size-limit:
         specifier: ^11.1.6
         version: 11.2.0


### PR DESCRIPTION
…b, Stepper + SCSS retirement

Completes the M2 milestone by rewriting the six remaining navigation and stepper components on the M0/M1 foundations, and retires the package-internal SCSS preprocessor pipeline.

Components rewritten (plain-CSS, ARIA-first, keyboard-complete):
- EpBreadcrumb (BreadcrumbNavigation.vue)
- EpNavbar     (NavigationBar.vue)
- EpTabNavigation (TabNavigation.vue) — underline/filled/pills, vertical,
  closable, addable, lazy, full ARIA tabs pattern with arrow/Home/End
- EpMenu       (MenuNavigation.vue + MenuNavigation/MenuItem.vue)
- EpSidebar    (SidebarNavigation.vue) — collapsible, responsive drawer
- EpStepper    (StepperComponent.vue) — clickable, progress-dots, states

Per-component:
- v-model:value (breaks v-model:modelValue / :current / :active)
- Unified EpSize + EpHue
- Histoire story + axe-core verified spec (8 new specs, 42 new tests)

SCSS retirement (package only — docs still uses SCSS transitionally):
- Removed "sass" from packages/ecosphere devDependencies
- Removed scss preprocessorOptions from vite + vitest configs
- Removed "**/*.scss" from sideEffects
- Removed "./styles/framework.scss" export entry
- All packages/ecosphere SFCs are now lang-CSS only

Validation:
- 23 test files / 189 tests pass
- vue-tsc type-check clean
- pnpm lint clean (pre-existing warnings only)
- Build: 19.51 kB gz (limit 60 kB)
- Docs build clean

BREAKING CHANGE: See .changeset/m2-component-hardening.md for the full consolidated M2 migration guide.